### PR TITLE
[F] Grid and Table improvements

### DIFF
--- a/components/composed/model/ModelGrid/ModelGridItem.tsx
+++ b/components/composed/model/ModelGrid/ModelGridItem.tsx
@@ -36,6 +36,9 @@ function ModelGridItem<
                   : "t-copy-sm a-color-light"
               }
             >
+              {cell.column.id !== "title" && (
+                <span>{`${cell.render("Header")}: `}</span>
+              )}
               {cell.render("Cell")}
             </div>
           );

--- a/components/composed/model/ModelGrid/ModelGridItem.tsx
+++ b/components/composed/model/ModelGrid/ModelGridItem.tsx
@@ -29,7 +29,7 @@ function ModelGridItem<
 
           return (
             <div key={i}>
-              {cell.column.id !== "title" && (
+              {cell.column.id !== "title" && cell.column.id !== "name" && (
                 <span>{`${cell.render("Header")}: `}</span>
               )}
               {cell.render("Cell")}

--- a/components/composed/model/ModelGrid/ModelGridItem.tsx
+++ b/components/composed/model/ModelGrid/ModelGridItem.tsx
@@ -28,14 +28,7 @@ function ModelGridItem<
             return;
 
           return (
-            <div
-              key={i}
-              className={
-                cell.column.id === "title"
-                  ? "t-weight-md a-link"
-                  : "t-copy-sm a-color-light"
-              }
-            >
+            <div key={i}>
               {cell.column.id !== "title" && (
                 <span>{`${cell.render("Header")}: `}</span>
               )}

--- a/components/composed/model/helpers/columns.tsx
+++ b/components/composed/model/helpers/columns.tsx
@@ -45,7 +45,7 @@ const thumbnail = {
   GridCell: ({ value }) => {
     return value?.image?.png ? (
       <Image
-        image={{ ...value?.image?.png, width: 150, height: 180 }}
+        image={{ ...value?.image?.png, width: 180, height: 180 }}
         objectFit="contain"
       />
     ) : null;

--- a/components/composed/model/helpers/columns.tsx
+++ b/components/composed/model/helpers/columns.tsx
@@ -28,7 +28,7 @@ const nameFactory = (route: string, label: string, accessor: any) => ({
         routeParams={{ slug: row.original.slug }}
         passHref
       >
-        <a>{value}</a>
+        <a className="t-weight-md a-link">{value}</a>
       </NamedLink>
     );
   },

--- a/components/composed/model/helpers/columns.tsx
+++ b/components/composed/model/helpers/columns.tsx
@@ -7,12 +7,14 @@ const createdAt = {
   id: "createdAt",
   disableSortBy: true,
   accessor: (row) => formatDate(row.createdAt),
+  truncate: true,
 };
 
 const updatedAt = {
   Header: "Updated At",
   id: "updatedAt",
   accessor: (row) => formatDate(row.updatedAt),
+  truncate: true,
 };
 
 // collection, title, title

--- a/components/composed/model/plugins/useRowActions.tsx
+++ b/components/composed/model/plugins/useRowActions.tsx
@@ -40,11 +40,11 @@ const renderOneAction = (row, action, actionConfig) => {
 
 const renderActions = (row, configuration) => {
   return (
-    <>
+    <div className="t-align-right">
       {Object.keys(configuration).map((action) => {
         return renderOneAction(row, action, configuration[action]);
       })}
-    </>
+    </div>
   );
 };
 

--- a/components/global/AppBody/styles.ts
+++ b/components/global/AppBody/styles.ts
@@ -2,16 +2,14 @@ import styled from "styled-components";
 import { basePadding } from "theme/mixins/appearance";
 
 export const Body = styled.div`
+  min-block-size: 100vh;
   display: flex;
   flex-direction: column;
-  min-height: 100vh;
-  max-height: 100vh;
-  overflow-x: hidden;
-  max-width: 100vw;
+  overflow: hidden;
 `;
 
 export const Main = styled.main`
-  flex: 2 1 auto;
+  flex-grow: 1;
   padding: ${basePadding(8)} var(--container-column-margin);
   margin: 0 auto;
   width: 100%;

--- a/components/layout/Grid/Grid.stories.tsx
+++ b/components/layout/Grid/Grid.stories.tsx
@@ -21,18 +21,29 @@ export default {
   },
 };
 
-function getRandImage() {
-  const width = 150 * 2;
+function renderRandImage() {
+  const width = Math.round(Math.random()) === 1 ? 180 * 2 : 150 * 2;
+  const height = 180 * 2;
 
   return (
     <Image
       image={{
-        height: width,
+        height: height,
         width: width,
         alt: "Alt text",
-        url: `https://via.placeholder.com/${width}/E1E1E5/67676B`,
+        url: `https://via.placeholder.com/${width}x${height}/E1E1E5/67676B`,
       }}
     />
+  );
+}
+
+function renderGridContent(i: number) {
+  return (
+    <>
+      <div className="t-weight-md a-link">Item {i}</div>
+      <div>Metadata</div>
+      <div>Metadata</div>
+    </>
   );
 }
 
@@ -42,13 +53,7 @@ export const Default: Story<Props> = () => (
   <Grid>
     <>
       {gridArray.map((i) => (
-        <Grid.Item key={i}>
-          <>
-            <div className="t-weight-md">Item {i}</div>
-            <div>Metadata</div>
-            <div>Metadata</div>
-          </>
-        </Grid.Item>
+        <Grid.Item key={i}>{renderGridContent(i)}</Grid.Item>
       ))}
     </>
   </Grid>
@@ -59,12 +64,8 @@ export const WithImages: Story<Props> = () => (
   <Grid>
     <>
       {gridArray.map((i) => (
-        <Grid.Item key={i} thumbnail={getRandImage()}>
-          <>
-            <div className="t-weight-md">Item {i}</div>
-            <div>Metadata</div>
-            <div>Metadata</div>
-          </>
+        <Grid.Item key={i} thumbnail={renderRandImage()}>
+          {renderGridContent(i)}
         </Grid.Item>
       ))}
     </>
@@ -79,13 +80,9 @@ export const WithCheckboxes: Story<Props> = ({ showCheckboxes }) => (
         <Grid.Item
           key={i}
           checkboxProps={{ "aria-label": "Select item" }}
-          thumbnail={getRandImage()}
+          thumbnail={renderRandImage()}
         >
-          <>
-            <div className="t-weight-md">Item {i}</div>
-            <div>Metadata</div>
-            <div>Metadata</div>
-          </>
+          {renderGridContent(i)}
         </Grid.Item>
       ))}
     </>
@@ -103,13 +100,9 @@ export const WithActions: Story<Props> = ({ showCheckboxes }) => (
           key={i}
           checkboxProps={{ "aria-label": "Select item" }}
           actions={<ButtonControl icon="edit" aria-label="Delete item" />}
-          thumbnail={getRandImage()}
+          thumbnail={renderRandImage()}
         >
-          <>
-            <div className="t-weight-md">Item {i}</div>
-            <div>Metadata</div>
-            <div>Metadata</div>
-          </>
+          {renderGridContent(i)}
         </Grid.Item>
       ))}
     </>

--- a/components/layout/Grid/Grid.styles.ts
+++ b/components/layout/Grid/Grid.styles.ts
@@ -10,15 +10,8 @@ const TABLET_BREAK = 70;
 
 export const Wrapper = styled.div<Partial<Props>>`
   --checkbox-opacity: 0;
-  display: grid;
-  row-gap: var(--grid-column-gap);
-  column-gap: var(--grid-column-gap);
-  grid-template-columns: repeat(4, 1fr);
-  margin-inline: -${basePadding(4)};
-  margin-block-start: ${basePadding(4)};
-
-  ${respond(`grid-template-columns: repeat(2, 1fr);`, 60)}
-  ${respond(`grid-template-columns: repeat(1, 1fr);`, MOBILE_BREAK)}
+  border-top: 1px solid var(--border-color);
+  border-bottom: 1px solid var(--border-color);
 
   ${({ showCheckboxes }) => showCheckboxes && `--checkbox-opacity: 1;`}
 
@@ -26,10 +19,23 @@ export const Wrapper = styled.div<Partial<Props>>`
     css`
       --checkbox-opacity: 1;
       --actions-opacity: 1;
-      margin-inline: auto;
     `,
     TABLET_BREAK
   )}
+`;
+
+export const Inner = styled.div`
+  display: grid;
+  row-gap: var(--grid-column-gap);
+  column-gap: var(--grid-column-gap);
+  grid-template-columns: repeat(4, 1fr);
+  margin-inline: -${basePadding(4)};
+  padding-block: ${basePadding(4)} ${basePadding(8)};
+
+  ${respond(`grid-template-columns: repeat(2, 1fr);`, 60)}
+  ${respond(`grid-template-columns: repeat(1, 1fr);`, MOBILE_BREAK)}
+
+  ${respond(` margin-inline: auto;`, TABLET_BREAK)}
 `;
 
 export const Item = styled.div`

--- a/components/layout/Grid/Grid.styles.ts
+++ b/components/layout/Grid/Grid.styles.ts
@@ -116,8 +116,10 @@ export const Thumbnail = styled.div`
 
 export const Children = styled.div`
   grid-area: children;
+  color: var(--color-light);
 
   > * + * {
     margin-block-start: ${basePadding(2)};
+    font-size: var(--font-size-sm);
   }
 `;

--- a/components/layout/Grid/Grid.styles.ts
+++ b/components/layout/Grid/Grid.styles.ts
@@ -1,6 +1,7 @@
 import styled, { css } from "styled-components";
 import { aBgLight, basePadding } from "theme/mixins/appearance";
-import { respond } from "theme/mixins/base";
+import { fluidScale, respond } from "theme/mixins/base";
+import { pxToRem } from "theme/mixins/functions";
 import Grid from "./Grid";
 type Props = React.ComponentProps<typeof Grid>;
 
@@ -12,10 +13,11 @@ export const Wrapper = styled.div<Partial<Props>>`
   display: grid;
   row-gap: var(--grid-column-gap);
   column-gap: var(--grid-column-gap);
-  margin-inline: -${basePadding(4)};
   grid-template-columns: repeat(4, 1fr);
+  margin-inline: -${basePadding(4)};
+  margin-block-start: ${basePadding(4)};
 
-  ${respond(`grid-template-columns: repeat(2, 1fr);`, TABLET_BREAK)}
+  ${respond(`grid-template-columns: repeat(2, 1fr);`, 60)}
   ${respond(`grid-template-columns: repeat(1, 1fr);`, MOBILE_BREAK)}
 
   ${({ showCheckboxes }) => showCheckboxes && `--checkbox-opacity: 1;`}
@@ -34,7 +36,7 @@ export const Item = styled.div`
   display: grid;
   grid-template:
     "checkbox actions" auto
-    "image image" minmax(auto, 180px)
+    "image image" auto
     "children children" 1fr
     / auto 1fr;
   padding-block: ${basePadding(2)} ${basePadding(4)};
@@ -48,7 +50,7 @@ export const Item = styled.div`
     `
       grid-template:
         "checkbox image children actions" 1fr
-        / auto minmax(auto, 64px) 1fr auto;
+        / auto auto 1fr auto;
       padding-inline: 0;
       padding-block-start: 0;
       gap: ${basePadding(3)};
@@ -76,26 +78,32 @@ export const Item = styled.div`
 export const Checkbox = styled.div`
   grid-area: checkbox;
   opacity: var(--checkbox-opacity, 0);
-  padding-block-start: ${basePadding(2)};
-  min-height: ${basePadding(10)};
+  padding-block: ${basePadding(2)};
 `;
 
 export const Actions = styled.div`
   grid-area: actions;
   opacity: var(--actions-opacity, 0);
   text-align: end;
+  --button-control-spacing: ${pxToRem(10)};
 `;
 
 export const Thumbnail = styled.div`
   grid-area: image;
   display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
   padding-inline-end: ${basePadding(2)};
   padding-block-end: ${basePadding(2)};
+  height: ${fluidScale("190px", "150px")};
+  max-width: 100%;
+  aspect-ratio: 1 / 1;
 
   ${respond(
-    css`
+    `
       display: block;
       padding-block-end: 0;
+      height: 60px;
     `,
     MOBILE_BREAK
   )}

--- a/components/layout/Grid/Grid.tsx
+++ b/components/layout/Grid/Grid.tsx
@@ -4,7 +4,9 @@ import GridItem from "./GridItem";
 
 const Grid = ({ children, showCheckboxes }: Props) => {
   return (
-    <Styled.Wrapper showCheckboxes={showCheckboxes}>{children}</Styled.Wrapper>
+    <Styled.Wrapper showCheckboxes={showCheckboxes}>
+      <Styled.Inner>{children}</Styled.Inner>
+    </Styled.Wrapper>
   );
 };
 

--- a/components/layout/PageCountActions/PageCountActions.styles.ts
+++ b/components/layout/PageCountActions/PageCountActions.styles.ts
@@ -7,7 +7,6 @@ export const Wrapper = styled.div`
   align-items: center;
   min-height: ${basePadding(10)};
   padding-block-end: ${basePadding(2)};
-  border-bottom: 1px solid var(--border-color);
 `;
 
 export const Count = styled.div`

--- a/components/layout/PageCountActions/PageCountActions.styles.ts
+++ b/components/layout/PageCountActions/PageCountActions.styles.ts
@@ -2,11 +2,12 @@ import styled from "styled-components";
 import { basePadding } from "theme/mixins/appearance";
 
 export const Wrapper = styled.div`
-  min-height: ${basePadding(10)};
-  padding-block-end: ${basePadding(2)};
   display: flex;
   flex-wrap: wrap;
   align-items: center;
+  min-height: ${basePadding(10)};
+  padding-block-end: ${basePadding(2)};
+  border-bottom: 1px solid var(--border-color);
 `;
 
 export const Count = styled.div`

--- a/components/layout/Table/Table.styles.ts
+++ b/components/layout/Table/Table.styles.ts
@@ -47,7 +47,6 @@ interface TableWrapperProps {
 }
 
 export const Table = styled.table`
-  border-collapse: collapse;
   margin-inline: calc(var(--table-margin-left) * -1)
     calc(var(--table-margin-right) * -1);
   width: calc(100% + var(--table-margin-left) + var(--table-margin-right));
@@ -106,6 +105,7 @@ export const HeaderCellInner = styled.span`
 export const Cell = styled.td`
   padding-block: ${basePadding(2)};
   padding-inline-end: var(--table-column-gap);
+  max-width: 15vw;
 
   ${({ align }) =>
     align &&

--- a/components/layout/Table/Table.styles.ts
+++ b/components/layout/Table/Table.styles.ts
@@ -37,7 +37,7 @@ export const TableWrapper = styled.div<TableWrapperProps>`
         --table-margin-left: 0px;
       }
     `,
-    100
+    110
   )}
 `;
 
@@ -83,7 +83,7 @@ export const HeaderCell = styled.th`
         border-bottom: 0;
       }
     `,
-    100,
+    110,
     "min"
   )}
 `;

--- a/components/layout/Table/TableBody.tsx
+++ b/components/layout/Table/TableBody.tsx
@@ -37,7 +37,7 @@ function TableBody<
             return (
               <Styled.Cell
                 {...cellProps}
-                className={cell.column.truncate ? "t-truncate" : null}
+                className={cell.column?.truncate ? "t-truncate" : null}
               >
                 {cell.render("Cell")}
               </Styled.Cell>

--- a/components/layout/Table/TableBody.tsx
+++ b/components/layout/Table/TableBody.tsx
@@ -35,7 +35,12 @@ function TableBody<
               ...(cell.getCellProps && cell.getCellProps()),
             };
             return (
-              <Styled.Cell {...cellProps}>{cell.render("Cell")}</Styled.Cell>
+              <Styled.Cell
+                {...cellProps}
+                className={cell.column.truncate ? "t-truncate" : null}
+              >
+                {cell.render("Cell")}
+              </Styled.Cell>
             );
           })}
           <Styled.Cell role="presentation" />

--- a/components/layout/Table/TableCell.tsx
+++ b/components/layout/Table/TableCell.tsx
@@ -1,19 +1,31 @@
 import React from "react";
 import * as Styled from "./Table.styles";
 
-const TableCell = ({ children, role, align, ...cellProps }: CellProps) => {
+function TableCell({
+  children,
+  role,
+  align,
+  truncate,
+  ...cellProps
+}: CellProps) {
   // role should be rowheader if first
   return (
-    <Styled.Cell role={role} align={align} {...cellProps}>
+    <Styled.Cell
+      className={truncate ? "t-truncate" : null}
+      role={role}
+      align={align}
+      {...cellProps}
+    >
       {children}
     </Styled.Cell>
   );
-};
+}
 
 interface CellProps {
   children?: React.ReactNode | React.ReactNode[] | Element | Element[];
   role: "gridcell" | "rowheader";
   align?: "left" | "right" | "center";
+  truncate?: boolean;
 }
 
 export default TableCell;

--- a/theme/base/resets.ts
+++ b/theme/base/resets.ts
@@ -126,7 +126,7 @@ export default css`
     border-collapse: inherit;
     border-spacing: 0;
     border-color: inherit;
-    text-align: left;
+    text-align: start;
     font-weight: inherit;
   }
 `;

--- a/theme/base/resets.ts
+++ b/theme/base/resets.ts
@@ -109,4 +109,24 @@ export default css`
     color: inherit;
     text-decoration: none;
   }
+
+  /* Remove table styling */
+  table,
+  thead,
+  tbody,
+  tfoot,
+  tr,
+  th,
+  td {
+    width: auto;
+    height: auto;
+    margin: 0;
+    padding: 0;
+    border: none;
+    border-collapse: inherit;
+    border-spacing: 0;
+    border-color: inherit;
+    text-align: left;
+    font-weight: inherit;
+  }
 `;

--- a/theme/base/resets.ts
+++ b/theme/base/resets.ts
@@ -45,7 +45,7 @@ export default css`
 
   /* Set core body defaults */
   body {
-    min-height: 100vh;
+    min-block-size: 100vh;
     text-rendering: geometricPrecision;
   }
 

--- a/theme/base/variables.ts
+++ b/theme/base/variables.ts
@@ -86,7 +86,8 @@ export function setZIndexVars() {
 export const breakpoints = {
   140: "1400px",
   120: "1280px",
-  100: "1000px",
+  110: "1100px",
+  100: "1024px",
   80: "834px",
   70: "768px",
   60: "667px",

--- a/theme/base/variables.ts
+++ b/theme/base/variables.ts
@@ -89,6 +89,7 @@ export const breakpoints = {
   100: "1000px",
   80: "834px",
   70: "768px",
+  60: "667px",
   tableBreak: "540px",
   50: "540px",
   40: "414px",

--- a/theme/mixins/appearance.ts
+++ b/theme/mixins/appearance.ts
@@ -99,6 +99,7 @@ export function aBaseInput() {
 export const aLink = (color?: string) => css`
   color: var(--${color || "accent-color"}, inherit);
   transition: var(--color-transition);
+  cursor: pointer;
 
   &:hover {
     color: var(--accent-color);

--- a/theme/mixins/typography.ts
+++ b/theme/mixins/typography.ts
@@ -32,3 +32,9 @@ export function tHeading(size: 1 | 2 | 3 | 4 | 5 | 6) {
     line-height: var(${`--line-height-h${size}`});
   `;
 }
+
+export const tTruncate = `
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;

--- a/theme/utility/typography.ts
+++ b/theme/utility/typography.ts
@@ -1,7 +1,7 @@
 // Utility typography classes
 // --------------------
 import { css } from "styled-components";
-import { tLabel, tList } from "../mixins/typography";
+import { tLabel, tList, tTruncate } from "../mixins/typography";
 import { aLink } from "../mixins/appearance";
 
 export default css`
@@ -60,5 +60,9 @@ export default css`
     ol {
       ${tList}
     }
+  }
+
+  .t-truncate {
+    ${tTruncate}
   }
 `;

--- a/types/react-table-config.d.ts
+++ b/types/react-table-config.d.ts
@@ -52,7 +52,9 @@ declare module "react-table" {
 
   export interface ColumnInstance<
     D extends Record<string, unknown> = Record<string, unknown>
-  > extends UseSortByColumnProps<D> {}
+  > extends UseSortByColumnProps<D> {
+    truncate?: boolean;
+  }
 
   // export interface Cell<
   //   D extends Record<string, unknown> = Record<string, unknown>,


### PR DESCRIPTION
- Add labels to meta data in grid view 
- Style table item link the same as grid
- Allow some cells to be truncated
- Align table actions to the right

TODO:
- [x] Selecting items in mobile sometimes has a weird bug with the layout, where extra padding is added to the bottom of the page
- [x] Table checkboxes are hidden at 1024px width (responsive size needs adjusting)
- [x] "title" is next to name in grid mobile view, should be removed
- [x] Extra spacing in grids without images

~Actions should roll up into an ellipsis button on mobile~ Going to make a separate issue for this