### PR TITLE
[B] Fix pagination

### DIFF
--- a/hooks/index.ts
+++ b/hooks/index.ts
@@ -1,7 +1,7 @@
 export { default as useBreadcrumbs } from "./useBreadcrumbs";
 export { default as useAuthenticatedQuery } from "./useAuthenticatedQuery";
 export { default as useAuthenticatedFetchKey } from "./useAuthenticatedFetchKey";
-export { default as useGetQuery } from "./useGetQuery";
+export { default as useBaseListQueryVars } from "./useBaseListQueryVars";
 export { default as useHasRole } from "./useHasRole";
 export { default as useIsAuthenticated } from "./useIsAuthenticated";
 export { default as useLatest } from "./useLatest";

--- a/hooks/useBaseListQueryVars.ts
+++ b/hooks/useBaseListQueryVars.ts
@@ -1,0 +1,19 @@
+import { useRouter } from "next/router";
+import get from "lodash/get";
+import { SimpleOrder } from "types/graphql-schema";
+
+/**
+ * Gets and returns shared list query vars, like page and order
+ *
+ * @returns ViewerContext state
+ */
+export default function useBaseListQueryVars(): {
+  page: number;
+  order: SimpleOrder;
+} {
+  const router = useRouter();
+  const page = parseInt(get(router, "query.page", 1));
+  const order = get(router, "query.order", "RECENT");
+
+  return { page, order };
+}

--- a/pages/collections/[slug]/collections.tsx
+++ b/pages/collections/[slug]/collections.tsx
@@ -4,9 +4,11 @@ import { collectionsCollectionChildQuery as Query } from "__generated__/collecti
 import CollectionList from "components/composed/collection/CollectionList";
 import CollectionLayout from "components/composed/collection/CollectionLayout";
 import { QueryWrapper } from "components/api";
-import { useRouteSlug } from "hooks";
+import { useRouteSlug, useBaseListQueryVars } from "hooks";
 
 function CollectionChildCollections() {
+  const queryVars = useBaseListQueryVars();
+
   const collectionSlug = useRouteSlug();
   // TODO: This should 404 instead of returning null.
   if (!collectionSlug) return null;
@@ -14,7 +16,7 @@ function CollectionChildCollections() {
   return (
     <QueryWrapper<Query>
       query={query}
-      initialVariables={{ collectionSlug, order: "RECENT", page: 1 }}
+      initialVariables={{ ...queryVars, collectionSlug }}
     >
       {({ data }) => {
         // TODO: We should 404 if there is no collection

--- a/pages/collections/[slug]/items.tsx
+++ b/pages/collections/[slug]/items.tsx
@@ -5,9 +5,11 @@ import { itemsCollectionChildQuery as Query } from "__generated__/itemsCollectio
 import CollectionLayout from "components/composed/collection/CollectionLayout";
 import { Page } from "types/page";
 import { QueryWrapper } from "components/api";
-import { useRouteSlug } from "hooks";
+import { useRouteSlug, useBaseListQueryVars } from "hooks";
 
 const CollectionChildItems: Page = () => {
+  const queryVars = useBaseListQueryVars();
+
   const collectionSlug = useRouteSlug();
   // TODO: This should 404 instead of returning null.
   if (!collectionSlug) return null;
@@ -15,7 +17,7 @@ const CollectionChildItems: Page = () => {
   return (
     <QueryWrapper<Query>
       query={query}
-      initialVariables={{ collectionSlug, order: "RECENT", page: 1 }}
+      initialVariables={{ ...queryVars, collectionSlug }}
     >
       {({ data }) => {
         // TODO: We should 404 if there is no collection

--- a/pages/collections/index.tsx
+++ b/pages/collections/index.tsx
@@ -3,13 +3,13 @@ import { graphql } from "react-relay";
 import CollectionList from "components/composed/collection/CollectionList";
 import { QueryWrapper } from "components/api";
 import { collectionsQuery as Query } from "__generated__/collectionsQuery.graphql";
+import { useBaseListQueryVars } from "hooks";
 
 export default function CollectionListView() {
+  const queryVars = useBaseListQueryVars();
+
   return (
-    <QueryWrapper<Query>
-      query={query}
-      initialVariables={{ order: "RECENT", page: 1 }}
-    >
+    <QueryWrapper<Query> query={query} initialVariables={queryVars}>
       {({ data }) => {
         if (!data) return null;
         return <CollectionList<Query> data={data?.viewer?.collections} />;

--- a/pages/communities/[slug]/collections.tsx
+++ b/pages/communities/[slug]/collections.tsx
@@ -2,12 +2,14 @@ import React from "react";
 import { graphql } from "react-relay";
 import CollectionList from "components/composed/collection/CollectionList";
 import { QueryWrapper } from "components/api";
-import { useRouteSlug } from "hooks";
+import { useRouteSlug, useBaseListQueryVars } from "hooks";
 import { collectionsCommunityChildQuery as Query } from "__generated__/collectionsCommunityChildQuery.graphql";
 import CommunityLayout from "components/composed/community/CommunityLayout";
 import { Page } from "types/page";
 
 const CommunityChildCollections: Page = () => {
+  const queryVars = useBaseListQueryVars();
+
   const communitySlug = useRouteSlug();
   // TODO: This should 404 instead of returning null.
   if (!communitySlug) return null;
@@ -15,7 +17,7 @@ const CommunityChildCollections: Page = () => {
   return (
     <QueryWrapper<Query>
       query={query}
-      initialVariables={{ communitySlug, order: "RECENT", page: 1 }}
+      initialVariables={{ communitySlug, ...queryVars }}
     >
       {({ data }) => {
         // TODO: We should 404 if there is no collection

--- a/pages/communities/index.tsx
+++ b/pages/communities/index.tsx
@@ -3,13 +3,13 @@ import { graphql } from "react-relay";
 import CommunityList from "components/composed/community/CommunityList";
 import { QueryWrapper } from "components/api";
 import type { communitiesQuery as Query } from "__generated__/communitiesQuery.graphql";
+import { useBaseListQueryVars } from "hooks";
 
 export default function CommunityListView() {
+  const queryVars = useBaseListQueryVars();
+
   return (
-    <QueryWrapper<Query>
-      query={query}
-      initialVariables={{ order: "RECENT", page: 1 }}
-    >
+    <QueryWrapper<Query> query={query} initialVariables={queryVars}>
       {({ data }) => {
         if (!data) return null;
         return <CommunityList<Query> data={data?.communities} />;

--- a/pages/contributors/[slug]/collections.tsx
+++ b/pages/contributors/[slug]/collections.tsx
@@ -1,11 +1,9 @@
 import React from "react";
-import { useRouter } from "next/router";
 import { RouteHelper } from "routes";
 import ContributorLayout from "components/composed/contributor/ContributorLayout";
 import { Page } from "types/page";
 
 const ContributorCollectionContributions: Page = () => {
-  const router = useRouter();
   const activeRoute = RouteHelper.activeRoute();
 
   return <>{activeRoute?.label}</>;

--- a/pages/contributors/[slug]/details.tsx
+++ b/pages/contributors/[slug]/details.tsx
@@ -1,11 +1,9 @@
 import React from "react";
-import { useRouter } from "next/router";
 import { RouteHelper } from "routes";
 import ContributorLayout from "components/composed/contributor/ContributorLayout";
 import { Page } from "types/page";
 
 const ContributorDetail: Page = () => {
-  const router = useRouter();
   const activeRoute = RouteHelper.activeRoute();
 
   return <>{activeRoute?.label}</>;

--- a/pages/contributors/[slug]/items.tsx
+++ b/pages/contributors/[slug]/items.tsx
@@ -1,11 +1,9 @@
 import React from "react";
-import { useRouter } from "next/router";
 import { RouteHelper } from "routes";
 import ContributorLayout from "components/composed/contributor/ContributorLayout";
 import { Page } from "types/page";
 
 const ContributorItemContributions: Page = () => {
-  const router = useRouter();
   const activeRoute = RouteHelper.activeRoute();
 
   return <>{activeRoute?.label}</>;

--- a/pages/contributors/index.tsx
+++ b/pages/contributors/index.tsx
@@ -3,13 +3,13 @@ import { graphql } from "react-relay";
 import ContributorList from "components/composed/contributor/ContributorList";
 import { QueryWrapper } from "components/api";
 import { contributorsQuery as Query } from "__generated__/contributorsQuery.graphql";
+import { useBaseListQueryVars } from "hooks";
 
 export default function ContributorListView() {
+  const queryVars = useBaseListQueryVars();
+
   return (
-    <QueryWrapper<Query>
-      query={query}
-      initialVariables={{ order: "RECENT", page: 1 }}
-    >
+    <QueryWrapper<Query> query={query} initialVariables={queryVars}>
       {({ data }) => {
         if (!data) return null;
         return <ContributorList<Query> data={data?.contributors} />;

--- a/pages/items/index.tsx
+++ b/pages/items/index.tsx
@@ -3,13 +3,13 @@ import { graphql } from "react-relay";
 import ItemList from "components/composed/item/ItemList";
 import { QueryWrapper } from "components/api";
 import { itemsQuery as Query } from "__generated__/itemsQuery.graphql";
+import { useBaseListQueryVars } from "hooks";
 
 export default function ItemListView() {
+  const queryVars = useBaseListQueryVars();
+
   return (
-    <QueryWrapper<Query>
-      query={query}
-      initialVariables={{ order: "RECENT", page: 1 }}
-    >
+    <QueryWrapper<Query> query={query} initialVariables={queryVars}>
       {({ data }) => {
         if (!data) return null;
         return <ItemList<Query> data={data?.viewer?.items} />;

--- a/pages/users/index.tsx
+++ b/pages/users/index.tsx
@@ -3,13 +3,13 @@ import { graphql } from "react-relay";
 import { usersQuery as Query } from "__generated__/usersQuery.graphql";
 import { QueryWrapper } from "components/api";
 import UserList from "components/composed/user/UserList";
+import { useBaseListQueryVars } from "hooks";
 
 export default function UserListView() {
+  const queryVars = useBaseListQueryVars();
+
   return (
-    <QueryWrapper<Query>
-      query={query}
-      initialVariables={{ order: "RECENT", page: 1 }}
-    >
+    <QueryWrapper<Query> query={query} initialVariables={queryVars}>
       {({ data }) => {
         if (!data) return null;
         return <UserList<Query> data={data?.users} />;


### PR DESCRIPTION
The problem:
Pagination and ordering are not working as expected. Both should be controlled using URL query parameters, so that links to a specific page and order can be shared. Currently clicking on next page or an order does nothing.

This PR fixes the issue by getting the query params from the router and passing them to QueryWrapper. There needs to be a little further refactoring to prevent the page from reloading everything (header, search bar, etc) when getting new items.

BUT! I noticed there is a `setVariables` method getting passed from QueryWrapper to its children. It's currently not used in any lists. 

I want to make sure I'm not stepping on anyone's toes here before I make further changes. Are we all on the same page for using the URL query to search, sort, and paginate the list?