### PR TITLE
[B] Address storybook failed imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "wdp-admin-ui",
   "version": "0.1.0",
   "private": true,
+  "sideEffects": false,
   "engines": {
     "npm": ">=7.17.0"
   },


### PR DESCRIPTION
This flag disabled webpack optimization.sideEffects. See:

https://webpack.js.org/configuration/optimization/#optimizationsideeffects

Without setting this flag, Storybook is failing to import modules
properly. It's unclear why this flag resolves the problem, so this may
only be an interim fix.