### PR TITLE
[F] Add secondary headers to layouts

### DIFF
--- a/components/atomic/SidebarNav/SidebarNav.tsx
+++ b/components/atomic/SidebarNav/SidebarNav.tsx
@@ -15,7 +15,7 @@ const SidebarNav = ({ links, className }: Props) => {
 
     return (
       <NamedLink route={route} query={query} passHref>
-        <Styled.Link active={active}>{t(label)}</Styled.Link>
+        <Styled.Link active={active}>{t(`navLabels.${label}`)}</Styled.Link>
       </NamedLink>
     );
   };

--- a/components/composed/collection/CollectionLayout/CollectionLayout.tsx
+++ b/components/composed/collection/CollectionLayout/CollectionLayout.tsx
@@ -2,6 +2,8 @@ import React, { ReactNode } from "react";
 import { graphql } from "react-relay";
 import type { CollectionLayoutFragment$key } from "@/relay/CollectionLayoutFragment.graphql";
 import { ContentSidebar, PageHeader } from "components/layout";
+import { RouteHelper } from "routes";
+import { useTranslation } from "react-i18next";
 import {
   useBreadcrumbs,
   useMaybeFragment,
@@ -20,6 +22,8 @@ export default function CollectionLayout({
 }) {
   const collection = useMaybeFragment(fragment, data);
   const breadcrumbs = useBreadcrumbs(collection || null);
+  const activeRoute = RouteHelper.activeRoute();
+  const { t } = useTranslation();
   const slug = useRouteSlug() || undefined;
   const manageRoutes = useChildRouteLinks("collection.manage", { slug });
   const tabRoutes = useChildRouteLinks("collection", { slug });
@@ -32,7 +36,15 @@ export default function CollectionLayout({
         tabRoutes={tabRoutes}
       />
       {showSidebar ? (
-        <ContentSidebar sidebarLinks={manageRoutes}>{children}</ContentSidebar>
+        <ContentSidebar sidebarLinks={manageRoutes}>
+          {activeRoute && activeRoute.label && (
+            <PageHeader
+              headerStyle="secondary"
+              title={t(`navLabels.${activeRoute.label}`)}
+            />
+          )}
+          {children}
+        </ContentSidebar>
       ) : (
         children
       )}

--- a/components/composed/community/CommunityLayout/CommunityLayout.tsx
+++ b/components/composed/community/CommunityLayout/CommunityLayout.tsx
@@ -3,7 +3,8 @@ import { graphql } from "react-relay";
 import type { CommunityLayoutFragment$key } from "@/relay/CommunityLayoutFragment.graphql";
 import { PageHeader, ContentSidebar } from "components/layout";
 import { useChildRouteLinks, useMaybeFragment, useRouteSlug } from "hooks";
-
+import { RouteHelper } from "routes";
+import { useTranslation } from "react-i18next";
 export default function CommunityLayout({
   children,
   showSidebar = false,
@@ -14,7 +15,8 @@ export default function CommunityLayout({
   data?: CommunityLayoutFragment$key | null;
 }) {
   const community = useMaybeFragment(fragment, data);
-
+  const activeRoute = RouteHelper.activeRoute();
+  const { t } = useTranslation();
   const slug = useRouteSlug() || undefined;
   const manageRoutes = useChildRouteLinks("community.manage", { slug });
   const tabRoutes = useChildRouteLinks("community", { slug });
@@ -23,7 +25,15 @@ export default function CommunityLayout({
     <section>
       <PageHeader title={community?.name} tabRoutes={tabRoutes} />
       {showSidebar ? (
-        <ContentSidebar sidebarLinks={manageRoutes}>{children}</ContentSidebar>
+        <ContentSidebar sidebarLinks={manageRoutes}>
+          {activeRoute && activeRoute.label && (
+            <PageHeader
+              headerStyle="secondary"
+              title={t(`navLabels.${activeRoute.label}`)}
+            />
+          )}
+          {children}
+        </ContentSidebar>
       ) : (
         children
       )}

--- a/components/composed/contributor/ContributorLayout/ContributorLayout.tsx
+++ b/components/composed/contributor/ContributorLayout/ContributorLayout.tsx
@@ -2,6 +2,9 @@ import React, { ReactNode } from "react";
 import { graphql } from "react-relay";
 import { useChildRouteLinks, useMaybeFragment, useRouteSlug } from "hooks";
 import type { ContributorLayoutFragment$key } from "@/relay/ContributorLayoutFragment.graphql";
+import { RouteHelper } from "routes";
+import { useTranslation } from "react-i18next";
+
 import { PageHeader, ContentSidebar } from "components/layout";
 import ContributorDisplayName from "../ContributorDisplayName";
 
@@ -13,6 +16,8 @@ export default function ContributorLayout({
   data?: ContributorLayoutFragment$key | null;
 }) {
   const slug = useRouteSlug() || undefined;
+  const activeRoute = RouteHelper.activeRoute();
+  const { t } = useTranslation();
   const manageRoutes = useChildRouteLinks("contributor", { slug });
   const contributor = useMaybeFragment(fragment, data);
 
@@ -21,7 +26,15 @@ export default function ContributorLayout({
       <PageHeader
         title={<ContributorDisplayName contributor={contributor} />}
       />
-      <ContentSidebar sidebarLinks={manageRoutes}>{children}</ContentSidebar>
+      <ContentSidebar sidebarLinks={manageRoutes}>
+        {activeRoute && activeRoute.label && (
+          <PageHeader
+            headerStyle="secondary"
+            title={t(`navLabels.${activeRoute.label}`)}
+          />
+        )}
+        {children}
+      </ContentSidebar>
     </section>
   );
 }

--- a/components/composed/item/ItemLayout/ItemLayout.tsx
+++ b/components/composed/item/ItemLayout/ItemLayout.tsx
@@ -7,6 +7,9 @@ import {
   useMaybeFragment,
   useChildRouteLinks,
 } from "hooks";
+import { RouteHelper } from "routes";
+import { useTranslation } from "react-i18next";
+
 import { ContentSidebar, PageHeader } from "components/layout";
 
 export default function ItemLayout({
@@ -20,6 +23,8 @@ export default function ItemLayout({
 }) {
   const item = useMaybeFragment(fragment, data);
   const breadcrumbs = useBreadcrumbs(item || null);
+  const activeRoute = RouteHelper.activeRoute();
+  const { t } = useTranslation();
   const slug = useRouteSlug() || undefined;
   const manageRoutes = useChildRouteLinks("item.manage", { slug });
   const tabRoutes = useChildRouteLinks("item", { slug });
@@ -32,7 +37,15 @@ export default function ItemLayout({
         tabRoutes={tabRoutes}
       />
       {showSidebar ? (
-        <ContentSidebar sidebarLinks={manageRoutes}>{children}</ContentSidebar>
+        <ContentSidebar sidebarLinks={manageRoutes}>
+          {activeRoute && activeRoute.label && (
+            <PageHeader
+              headerStyle="secondary"
+              title={t(`navLabels.${activeRoute.label}`)}
+            />
+          )}
+          {children}
+        </ContentSidebar>
       ) : (
         children
       )}

--- a/components/composed/user/UserLayout/UserLayout.tsx
+++ b/components/composed/user/UserLayout/UserLayout.tsx
@@ -2,6 +2,8 @@ import React, { ReactNode } from "react";
 import { ContentSidebar, PageHeader } from "components/layout";
 import { useChildRouteLinks, useMaybeFragment, useRouteSlug } from "hooks";
 import { graphql } from "react-relay";
+import { RouteHelper } from "routes";
+import { useTranslation } from "react-i18next";
 import { UserLayoutFragment$key } from "@/relay/UserLayoutFragment.graphql";
 
 type Props = {
@@ -17,12 +19,23 @@ export default function UserLayout({
 }: Props) {
   const user = useMaybeFragment(fragment, data);
   const slug = useRouteSlug() || undefined;
+  const activeRoute = RouteHelper.activeRoute();
+  const { t } = useTranslation();
   const manageRoutes = useChildRouteLinks("user", { slug });
+
   return (
     <section>
       <PageHeader title={user?.name} />
       {showSidebar ? (
-        <ContentSidebar sidebarLinks={manageRoutes}>{children}</ContentSidebar>
+        <ContentSidebar sidebarLinks={manageRoutes}>
+          {activeRoute && activeRoute.label && (
+            <PageHeader
+              headerStyle="secondary"
+              title={t(`navLabels.${activeRoute.label}`)}
+            />
+          )}
+          {children}
+        </ContentSidebar>
       ) : (
         children
       )}

--- a/components/layout/PageHeader/PageHeader.tsx
+++ b/components/layout/PageHeader/PageHeader.tsx
@@ -3,6 +3,7 @@ import { Breadcrumbs, NamedLink, TabNav } from "components/atomic";
 import * as Styled from "./PageHeader.styles";
 import { RouteHelper } from "routes";
 import isNil from "lodash/isNil";
+import { useTranslation } from "react-i18next";
 
 type BreadcrumbProps = React.ComponentProps<typeof Breadcrumbs>;
 type NamedLinkProps = React.ComponentProps<typeof NamedLink>;
@@ -19,7 +20,7 @@ const PageHeader = ({
   hideHeader = false,
 }: Props) => {
   const activeRoute = RouteHelper.activeRoute();
-
+  const { t } = useTranslation();
   return (
     <Styled.Header
       className={hideHeader ? "a-hidden" : ""}
@@ -41,7 +42,7 @@ const PageHeader = ({
                 <TabNav.Tab
                   active={activeRoute?.name.includes(namedLinkProps.route)}
                 >
-                  {label}
+                  {t(`navLabels.${label}`)}
                 </TabNav.Tab>
               </NamedLink>
             ))}

--- a/locales/en.json
+++ b/locales/en.json
@@ -195,6 +195,23 @@
     "name_plural": "names",
     "title": "title",
     "title_plural": "titles",
-    "details": "Details"
+    "navLabels": {
+      "details": "Details",
+      "collections": "Collections",
+      "items": "Items",
+      "manage": "Manage",
+      "roles": "Roles",
+      "members": "Members",
+      "order": "Orderings",
+      "links": "Links",
+      "access": "Access",
+      "pages": "Pages",
+      "contributions": "Contributions",
+      "rules": "Rules",
+      "files": "Files",
+      "permissions": "Permissions",
+      "collectionContributions": "Collection Contributions",
+      "itemContributions": "Item Contributions"
+    }
   }
 }

--- a/pages/contributors/[slug]/collections.tsx
+++ b/pages/contributors/[slug]/collections.tsx
@@ -21,6 +21,7 @@ function ContributorCollectionContributions() {
       {({ data }) => (
         <ContributorLayout data={data?.contributor}>
           <CollectionContributionList<Query>
+            hideHeader={true}
             data={data?.contributor?.collectionContributions}
             headerStyle="secondary"
           />

--- a/pages/contributors/[slug]/items.tsx
+++ b/pages/contributors/[slug]/items.tsx
@@ -21,6 +21,7 @@ function ContributorItemContributions() {
       {({ data }) => (
         <ContributorLayout data={data?.contributor}>
           <ItemContributionList<Query>
+            hideHeader={true}
             data={data?.contributor?.itemContributions}
             headerStyle="secondary"
           />

--- a/routes/baseRoutes.ts
+++ b/routes/baseRoutes.ts
@@ -218,12 +218,12 @@ export const baseRoutes: BaseRoute[] = [
           {
             name: "contributor.collections",
             path: "/contributors/[slug]/collections",
-            label: "glossary.collection_contribution.label",
+            label: "collectionContributions",
           },
           {
             name: "contributor.items",
             path: "/contributors/[slug]/items",
-            label: "glossary.item_contribution.label",
+            label: "itemContributions",
           },
         ],
       },


### PR DESCRIPTION
@jen-castiron and @1aurend — I went ahead and implemented these secondary headers in the layouts, building on your changes to PageHeader. Please feel free to adjust the approach in this PR in a subsequent commit if you're not happy with it. I just wanted these looking good for the demo tomorrow, and it only took a few minutes to get them in place.