### PR TITLE
[C] DRY PageHeader props

### DIFF
--- a/components/composed/collection/CollectionList/CollectionList.tsx
+++ b/components/composed/collection/CollectionList/CollectionList.tsx
@@ -9,6 +9,9 @@ import {
 import { graphql } from "react-relay";
 import ModelColumns from "components/composed/model/ModelColumns";
 import type { ModelTableActionProps } from "react-table";
+import PageHeader from "components/layout/PageHeader";
+
+type HeaderProps = React.ComponentProps<typeof PageHeader>;
 
 function CollectionList<T extends OperationType>({
   data,
@@ -56,10 +59,9 @@ function CollectionList<T extends OperationType>({
   );
 }
 
-interface CollectionListProps {
+interface CollectionListProps
+  extends Pick<HeaderProps, "headerStyle" | "hideHeader"> {
   data?: CollectionListFragment$key;
-  headerStyle?: "primary" | "secondary";
-  hideHeader?: boolean;
 }
 
 type CollectionNode = CollectionListFragment["nodes"][number];

--- a/components/composed/community/CommunityList/CommunityList.tsx
+++ b/components/composed/community/CommunityList/CommunityList.tsx
@@ -12,6 +12,9 @@ import { useMaybeFragment, useDrawerHelper, useDestroyer } from "hooks";
 import ModelListPage from "components/composed/model/ModelListPage";
 import ModelColumns from "components/composed/model/ModelColumns";
 import { DataViewOptions } from "components/atomic/DataViewToggle";
+import PageHeader from "components/layout/PageHeader";
+
+type HeaderProps = React.ComponentProps<typeof PageHeader>;
 
 function CommunityList<T extends OperationType>({
   data,
@@ -55,10 +58,9 @@ function CommunityList<T extends OperationType>({
   );
 }
 
-interface CommunityListProps {
+interface CommunityListProps
+  extends Pick<HeaderProps, "headerStyle" | "hideHeader"> {
   data?: CommunityListFragment$key;
-  headerStyle?: "primary" | "secondary";
-  hideHeader?: boolean;
 }
 
 type CommunityNode = CommunityListFragment["edges"][number]["node"];

--- a/components/composed/contribution/CollectionContributionList/CollectionContributionList.tsx
+++ b/components/composed/contribution/CollectionContributionList/CollectionContributionList.tsx
@@ -14,6 +14,9 @@ import ModelListPage from "components/composed/model/ModelListPage";
 import ModelColumns from "components/composed/model/ModelColumns";
 import { DataViewOptions } from "components/atomic/DataViewToggle";
 import GetContributorDisplayName from "components/composed/contributor/ContributorDisplayName";
+import PageHeader from "components/layout/PageHeader";
+
+type HeaderProps = React.ComponentProps<typeof PageHeader>;
 
 function CollectionContributionList<T extends OperationType>({
   data,
@@ -117,11 +120,10 @@ function CollectionContributionList<T extends OperationType>({
   );
 }
 
-interface CollectionContributionListProps {
+interface CollectionContributionListProps
+  extends Pick<HeaderProps, "headerStyle" | "hideHeader"> {
   data?: CollectionContributionListFragment$key;
   nameColumn?: "collection" | "contributor";
-  headerStyle?: "primary" | "secondary";
-  hideHeader?: boolean;
 }
 
 type CollectionContributionNode = CollectionContributionListFragment["nodes"][number];

--- a/components/composed/contribution/ItemContributionList/ItemContributionList.tsx
+++ b/components/composed/contribution/ItemContributionList/ItemContributionList.tsx
@@ -14,6 +14,9 @@ import ModelColumns from "components/composed/model/ModelColumns";
 import { DataViewOptions } from "components/atomic/DataViewToggle";
 import { NamedLink } from "components/atomic";
 import GetContributorDisplayName from "components/composed/contributor/ContributorDisplayName/ContributorDisplayName";
+import PageHeader from "components/layout/PageHeader";
+
+type HeaderProps = React.ComponentProps<typeof PageHeader>;
 
 function ItemContributionList<T extends OperationType>({
   data,
@@ -108,11 +111,10 @@ function ItemContributionList<T extends OperationType>({
   );
 }
 
-interface ItemContributionListProps {
+interface ItemContributionListProps
+  extends Pick<HeaderProps, "headerStyle" | "hideHeader"> {
   data?: ItemContributionListFragment$key;
-  headerStyle?: "primary" | "secondary";
   nameColumn?: "item" | "contributor";
-  hideHeader?: boolean;
 }
 
 type ItemContributionNode = ItemContributionListFragment["nodes"][number];

--- a/components/composed/contributor/ContributorList/ContributorList.tsx
+++ b/components/composed/contributor/ContributorList/ContributorList.tsx
@@ -14,6 +14,9 @@ import ModelColumns from "components/composed/model/ModelColumns";
 import { DataViewOptions } from "components/atomic/DataViewToggle";
 import { DrawerLink, ButtonControl } from "components/atomic";
 import { getContributorDisplayName } from "../ContributorDisplayName";
+import PageHeader from "components/layout/PageHeader";
+
+type HeaderProps = React.ComponentProps<typeof PageHeader>;
 
 function ContributorList<T extends OperationType>({
   data,
@@ -87,10 +90,9 @@ function ContributorList<T extends OperationType>({
   );
 }
 
-interface ContributorListProps {
+interface ContributorListProps
+  extends Pick<HeaderProps, "headerStyle" | "hideHeader"> {
   data?: ContributorListFragment$key;
-  headerStyle?: "primary" | "secondary";
-  hideHeader?: boolean;
 }
 
 type ContributorNode = ContributorListFragment["nodes"][number];

--- a/components/composed/item/ItemList/ItemList.tsx
+++ b/components/composed/item/ItemList/ItemList.tsx
@@ -10,6 +10,9 @@ import type { ModelTableActionProps } from "react-table";
 
 import ModelListPage from "components/composed/model/ModelListPage";
 import ModelColumns from "components/composed/model/ModelColumns";
+import PageHeader from "components/layout/PageHeader";
+
+type HeaderProps = React.ComponentProps<typeof PageHeader>;
 
 function ItemList<T extends OperationType>({
   data,
@@ -55,10 +58,9 @@ function ItemList<T extends OperationType>({
   );
 }
 
-interface ItemListProps {
+interface ItemListProps
+  extends Pick<HeaderProps, "headerStyle" | "hideHeader"> {
   data?: ItemListFragment$key;
-  headerStyle?: "primary" | "secondary";
-  hideHeader?: boolean;
 }
 
 type ItemNode = ItemListFragment["nodes"][number];

--- a/components/composed/model/ModelListHeader/ModelListHeader.tsx
+++ b/components/composed/model/ModelListHeader/ModelListHeader.tsx
@@ -5,11 +5,12 @@ import { useTranslation } from "react-i18next";
 import startCase from "lodash/startCase";
 import ModelAddButton from "components/composed/model/ModelAddButton";
 
-interface ModelHeaderProps {
+type HeaderProps = React.ComponentProps<typeof PageHeader>;
+
+interface ModelHeaderProps
+  extends Pick<HeaderProps, "headerStyle" | "hideHeader"> {
   modelName?: Lowercase<ModelNames>;
   buttons?: React.ReactNode;
-  headerStyle?: "primary" | "secondary";
-  hideHeader?: boolean;
 }
 
 function ModelListHeader({

--- a/components/composed/model/ModelListPage/ModelListPage.tsx
+++ b/components/composed/model/ModelListPage/ModelListPage.tsx
@@ -12,6 +12,9 @@ import type { ModelListActionsProps } from "components/composed/model/ModelListA
 import { QueryVariablesContext } from "contexts";
 import { OperationType } from "relay-runtime";
 import { useIsMobile } from "hooks";
+import PageHeader from "components/layout/PageHeader";
+
+type HeaderProps = React.ComponentProps<typeof PageHeader>;
 
 export type PaginatedConnectionish = Connectionish &
   ModelPaginationFragment$key &
@@ -22,11 +25,10 @@ type ModelListPageProps<
   U extends PaginatedConnectionish,
   V extends Record<string, unknown> = Record<string, unknown>
 > = Omit<ModelListProps<T, U, V>, "view"> &
-  Pick<ModelListActionsProps, "viewOptions"> & {
+  Pick<ModelListActionsProps, "viewOptions"> &
+  Pick<HeaderProps, "headerStyle" | "hideHeader"> & {
     defaultView?: ModelListActionsProps["active"];
     buttons?: ReactNode;
-    headerStyle?: "primary" | "secondary";
-    hideHeader?: boolean;
   };
 
 function ModelListPage<

--- a/components/composed/user/UserList/UserList.tsx
+++ b/components/composed/user/UserList/UserList.tsx
@@ -11,6 +11,9 @@ import { CellProps } from "react-table";
 import ModelListPage from "components/composed/model/ModelListPage";
 import ModelColumns from "components/composed/model/ModelColumns";
 import { DataViewOptions } from "components/atomic/DataViewToggle";
+import PageHeader from "components/layout/PageHeader";
+
+type HeaderProps = React.ComponentProps<typeof PageHeader>;
 
 function UserList<T extends OperationType>({
   data,
@@ -50,10 +53,9 @@ function UserList<T extends OperationType>({
   );
 }
 
-interface UserListProps {
+interface UserListProps
+  extends Pick<HeaderProps, "headerStyle" | "hideHeader"> {
   data?: UserListFragment$key;
-  headerStyle?: "primary" | "secondary";
-  hideHeader?: boolean;
 }
 
 type UserNode = UserListFragment["nodes"][number];


### PR DESCRIPTION
@jen-castiron I think these props are correct now, except `ModelListPage`. Which type there do I extend to add the header props? I have this, which I don't think is right:

```
type ModelListPageProps<
  T extends OperationType,
  U extends PaginatedConnectionish,
  V extends Record<string, unknown> = Record<string, unknown>
> = Omit<ModelListProps<T, U, V>, "view"> &
  Pick<ModelListActionsProps, "viewOptions"> &
  Pick<HeaderProps, "headerStyle" | "hideHeader"> & {
    defaultView?: ModelListActionsProps["active"];
    buttons?: ReactNode;
  };
```