### PR TITLE
[WIP] For discussion: different layout approach

### DIFF
--- a/components/composed/community/CommunityLayoutQuery/CommunityLayoutQuery.tsx
+++ b/components/composed/community/CommunityLayoutQuery/CommunityLayoutQuery.tsx
@@ -1,0 +1,44 @@
+import React, { ComponentProps } from "react";
+import { QueryWrapper } from "components/api";
+import { useRouteSlug, useBaseListQueryVars } from "hooks";
+import type { QueryLayoutProps, QueryPageComponentProps } from "types/page";
+import { HasFragment } from "types/graphql-helpers";
+
+import ErrorPage from "next/error";
+import CommunityLayout from "../CommunityLayout";
+
+function CommunityLayoutQuery<
+  Query extends CommunityQuery,
+  P extends QueryPageComponentProps<Query>
+>({
+  query,
+  PageComponent,
+  pageComponentProps,
+  ...layoutProps
+}: QueryLayoutProps<P, ComponentProps<typeof CommunityLayout>>) {
+  const queryVars = useBaseListQueryVars();
+  const communitySlug = useRouteSlug();
+  if (!communitySlug) return <ErrorPage statusCode={404} />;
+
+  return (
+    <QueryWrapper<Query>
+      query={query}
+      initialVariables={{ ...queryVars, communitySlug }}
+    >
+      {({ data }) => (
+        <CommunityLayout {...layoutProps} data={data?.community}>
+          <PageComponent data={data} {...pageComponentProps} />
+        </CommunityLayout>
+      )}
+    </QueryWrapper>
+  );
+}
+
+type CommunityQuery = {
+  readonly response: {
+    community: HasFragment<"CommunityLayoutFragment"> | null;
+  };
+  readonly variables: { communitySlug: string };
+};
+
+export default CommunityLayoutQuery;

--- a/components/composed/community/CommunityLayoutQuery/index.tsx
+++ b/components/composed/community/CommunityLayoutQuery/index.tsx
@@ -1,0 +1,1 @@
+export { default } from "./CommunityLayoutQuery";

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -66,7 +66,15 @@ const NGLPApp = ({
     }
   }
 
-  const getLayout = Component.getLayout || ((page) => page);
+  const defaultLayout = ({
+    PageComponent,
+    pageComponentProps,
+  }: {
+    PageComponent: typeof Component;
+    pageComponentProps: typeof pageProps;
+  }) => <PageComponent {...pageComponentProps} />;
+
+  const getLayout = Component.getLayout || defaultLayout;
 
   return (
     <React.Fragment>
@@ -83,7 +91,10 @@ const NGLPApp = ({
           <AppContextProvider>
             <AppBody>
               <Toaster />
-              {getLayout(<Component {...pageProps} />)}
+              {getLayout({
+                PageComponent: Component,
+                pageComponentProps: pageProps,
+              })}
               <DrawerController />
             </AppBody>
           </AppContextProvider>

--- a/pages/communities/[slug]/collections.tsx
+++ b/pages/communities/[slug]/collections.tsx
@@ -1,37 +1,30 @@
 import React from "react";
 import { graphql } from "react-relay";
-import { QueryWrapper } from "components/api";
-import { useRouteSlug, useBaseListQueryVars } from "hooks";
 import { collectionsSlugCommunitiesPagesQuery as Query } from "__generated__/collectionsSlugCommunitiesPagesQuery.graphql";
-
 import CollectionList from "components/composed/collection/CollectionList";
-import CommunityLayout from "components/composed/community/CommunityLayout";
-import ErrorPage from "next/error";
+import CommunityLayoutQuery from "components/composed/community/CommunityLayoutQuery";
+import type { GetLayout } from "types/page";
 
-function CommunityChildCollections() {
-  const queryVars = useBaseListQueryVars();
-  const communitySlug = useRouteSlug();
-  if (!communitySlug) return <ErrorPage statusCode={404} />;
-
+function CommunityChildCollections({ data }: Props) {
   return (
-    <QueryWrapper<Query>
-      query={query}
-      initialVariables={{ ...queryVars, communitySlug }}
-    >
-      {({ data }) => (
-        <CommunityLayout data={data?.community}>
-          <CollectionList<Query>
-            data={data?.community?.collections}
-            headerStyle="secondary"
-            hideHeader
-          />
-        </CommunityLayout>
-      )}
-    </QueryWrapper>
+    <CollectionList<Query>
+      data={data?.community?.collections}
+      headerStyle="secondary"
+      hideHeader
+    />
   );
 }
 
+const getLayout: GetLayout<Props> = (props) => {
+  return <CommunityLayoutQuery<Query, Props> query={query} {...props} />;
+};
+CommunityChildCollections.getLayout = getLayout;
+
 export default CommunityChildCollections;
+
+type Props = {
+  data: Query["response"];
+};
 
 const query = graphql`
   query collectionsSlugCommunitiesPagesQuery(

--- a/pages/communities/[slug]/manage/details.tsx
+++ b/pages/communities/[slug]/manage/details.tsx
@@ -1,31 +1,29 @@
 import React from "react";
 import { graphql } from "react-relay";
-import { QueryWrapper } from "components/api";
-import { useRouteSlug, useBaseListQueryVars } from "hooks";
 import type { detailsManageSlugCommunitiesPagesQuery as Query } from "@/relay/detailsManageSlugCommunitiesPagesQuery.graphql";
+import type { GetLayout } from "types/page";
 
 import CommunityUpdateForm from "components/composed/community/CommunityUpdateForm";
-import CommunityLayout from "components/composed/community/CommunityLayout";
-import ErrorPage from "next/error";
+import CommunityLayoutQuery from "components/composed/community/CommunityLayoutQuery";
 
-function CommunityDetails() {
-  const queryVars = useBaseListQueryVars();
-  const communitySlug = useRouteSlug();
-  if (!communitySlug) return <ErrorPage statusCode={404} />;
+function CommunityDetails({ data }: Props) {
+  if (!data || !data.community) return null;
 
-  return (
-    <QueryWrapper<Query>
-      query={query}
-      initialVariables={{ ...queryVars, communitySlug }}
-    >
-      {({ data }) => (
-        <CommunityLayout showSidebar data={data?.community}>
-          {data?.community && <CommunityUpdateForm data={data?.community} />}
-        </CommunityLayout>
-      )}
-    </QueryWrapper>
-  );
+  return <CommunityUpdateForm data={data?.community} />;
 }
+
+const getLayout: GetLayout<Props> = (props) => {
+  return (
+    <CommunityLayoutQuery<Query, Props> showSidebar query={query} {...props} />
+  );
+};
+CommunityDetails.getLayout = getLayout;
+
+export default CommunityDetails;
+
+type Props = {
+  data: Query["response"];
+};
 
 const query = graphql`
   query detailsManageSlugCommunitiesPagesQuery($communitySlug: Slug!) {
@@ -35,5 +33,3 @@ const query = graphql`
     }
   }
 `;
-
-export default CommunityDetails;

--- a/pages/communities/[slug]/manage/members.tsx
+++ b/pages/communities/[slug]/manage/members.tsx
@@ -1,30 +1,24 @@
 import React from "react";
 import { graphql } from "react-relay";
-import { QueryWrapper } from "components/api";
-import { useRouteSlug, useBaseListQueryVars } from "hooks";
-import type { detailsManageSlugCommunitiesPagesQuery as Query } from "@/relay/detailsManageSlugCommunitiesPagesQuery.graphql";
+import type { GetLayout } from "types/page";
+import type { membersManageSlugCommunitiesPagesQuery as Query } from "@/relay/membersManageSlugCommunitiesPagesQuery.graphql";
+import CommunityLayoutQuery from "components/composed/community/CommunityLayoutQuery";
 
-import CommunityLayout from "components/composed/community/CommunityLayout";
-import ErrorPage from "next/error";
-
-function CommunityMembers() {
-  const queryVars = useBaseListQueryVars();
-  const communitySlug = useRouteSlug();
-  if (!communitySlug) return <ErrorPage statusCode={404} />;
-
-  return (
-    <QueryWrapper<Query>
-      query={query}
-      initialVariables={{ ...queryVars, communitySlug }}
-    >
-      {({ data }) => (
-        <CommunityLayout showSidebar data={data?.community}>
-          Community Members
-        </CommunityLayout>
-      )}
-    </QueryWrapper>
-  );
+function CommunityDetails({ data: dataIgnored }: Props) {
+  return <div>Community Members</div>;
 }
+const getLayout: GetLayout<Props> = (props) => {
+  return (
+    <CommunityLayoutQuery<Query, Props> showSidebar query={query} {...props} />
+  );
+};
+CommunityDetails.getLayout = getLayout;
+
+export default CommunityDetails;
+
+type Props = {
+  data: Query["response"];
+};
 
 const query = graphql`
   query membersManageSlugCommunitiesPagesQuery($communitySlug: Slug!) {
@@ -33,5 +27,3 @@ const query = graphql`
     }
   }
 `;
-
-export default CommunityMembers;

--- a/pages/communities/[slug]/manage/roles.tsx
+++ b/pages/communities/[slug]/manage/roles.tsx
@@ -1,30 +1,24 @@
 import React from "react";
 import { graphql } from "react-relay";
-import { QueryWrapper } from "components/api";
-import { useRouteSlug, useBaseListQueryVars } from "hooks";
-import type { detailsManageSlugCommunitiesPagesQuery as Query } from "@/relay/detailsManageSlugCommunitiesPagesQuery.graphql";
+import type { GetLayout } from "types/page";
+import type { membersManageSlugCommunitiesPagesQuery as Query } from "@/relay/membersManageSlugCommunitiesPagesQuery.graphql";
+import CommunityLayoutQuery from "components/composed/community/CommunityLayoutQuery";
 
-import CommunityLayout from "components/composed/community/CommunityLayout";
-import ErrorPage from "next/error";
-
-function CommunityDetails() {
-  const queryVars = useBaseListQueryVars();
-  const communitySlug = useRouteSlug();
-  if (!communitySlug) return <ErrorPage statusCode={404} />;
-
-  return (
-    <QueryWrapper<Query>
-      query={query}
-      initialVariables={{ ...queryVars, communitySlug }}
-    >
-      {({ data }) => (
-        <CommunityLayout showSidebar data={data?.community}>
-          Community Roles
-        </CommunityLayout>
-      )}
-    </QueryWrapper>
-  );
+function CommunityDetails({ data: dataIgnored }: Props) {
+  return <div>Community Roles</div>;
 }
+const getLayout: GetLayout<Props> = (props) => {
+  return (
+    <CommunityLayoutQuery<Query, Props> showSidebar query={query} {...props} />
+  );
+};
+CommunityDetails.getLayout = getLayout;
+
+export default CommunityDetails;
+
+type Props = {
+  data: Query["response"];
+};
 
 const query = graphql`
   query rolesManageSlugCommunitiesPagesQuery($communitySlug: Slug!) {
@@ -33,5 +27,3 @@ const query = graphql`
     }
   }
 `;
-
-export default CommunityDetails;

--- a/types/graphql-helpers.d.ts
+++ b/types/graphql-helpers.d.ts
@@ -1,4 +1,4 @@
-import { OperationType } from "relay-runtime";
+import { FragmentRefs, OperationType } from "relay-runtime";
 import type { PageInfo } from "./graphql-schema";
 
 export type PathProxy<TRoot, T> = {
@@ -39,3 +39,7 @@ export type ExtractConnectionType<
 > = ResponseType[ConnectionName] extends Connectionish
   ? ResponseType[ConnectionName]
   : never;
+
+export type HasFragment<FragmentName> = {
+  " $fragmentRefs": FragmentRefs<FragmentName>;
+};

--- a/types/page.d.ts
+++ b/types/page.d.ts
@@ -1,12 +1,32 @@
 import { NextPage } from "next";
-import { ComponentType, ReactElement, ReactNode } from "react";
+import { ComponentType, ReactNode } from "react";
+import type { GraphQLTaggedNode, OperationType } from "relay-runtime";
 
-export type GetLayout = (page: ReactElement) => ReactNode;
+export interface GetLayoutProps<P = Record<string, unknown>> {
+  PageComponent: ComponentType<P>;
+  pageComponentProps: P;
+}
+
+export type GetLayout<P = Record<string, unknown>> = (
+  props: GetLayoutProps<P>
+) => ReactNode;
 
 // Next.js Component type (NextComponentType<NextPageContext, any, P>;)
 // does not include a `getLayout` function, so we need to define Page ourselves.
-// eslint-disable-next-line @typescript-eslint/ban-types
-export type Page<P = {}> = NextPage<P> & {
+export type Page<P = Record<string, unknown>> = NextPage<P> & {
   getLayout?: GetLayout;
-  layout?: ComponentType;
+  layout?: ComponentType<P>;
+};
+
+interface QueryPageComponentProps<Q extends OperationType> {
+  data?: Q["response"] | null;
+}
+
+type QueryLayoutProps<P extends QueryPageComponentProps, LayoutProps> = Omit<
+  LayoutProps,
+  "children"
+> & {
+  PageComponent: ComponentType<P>;
+  query: GraphQLTaggedNode;
+  pageComponentProps: P;
 };


### PR DESCRIPTION
This PR is still a POC showing how we can improve our approach to model Layout components (CommunityLayout, CollectionLayout, etc). These layouts are used on routes where there is a `[slug]` in the URL referencing a single model. This PR shows the approach for these routes:

```
/communities/[slug]/collections
/communities/[slug]/manage/details
/communities/[slug]/manage/roles
/communities/[slug]/manage/members
```

This PR introduces a `CommunityQueryLayout` component that sits between the Page component and the QueryLayout. The page has a `getLayout` function that wraps it in `CommunityQueryLayout` and passes it its query. The `CommunityQueryLayout` component is then responsible for executing the query, passing the data to `CommunityLayout` and rendering the page with its props. Because this wrapping component is rendered in `_app`, we avoid remounting the layout. 

Not only does this approach solve our remounting problem, it DRYs up the pages. Each page can be more focused on what it's rendering and no longer has to deal with getting its slug and executing the query with QueryWrapper.

### Caveat!
You will see a flash when you navigate from `/communities/[slug]/collections` to `/communities/[slug]/manage`. This is not a deficiency with this approach. That happens because the `/communities/[slug]/manage` redirects the user to `/communities/[slug]/manage/details` so the layout is remounted. That redirect isn't really necessary — we could adjust our navigation to render the redirect path if the route is a redirect to solve this problem. This is, however, a separate issue and not something I'm solving in this PR.

So, to see the user experience improvement, navigate between details / roles / members in the sidebar nav. The flash of the title should no longer be an issue.