### PR TITLE
[F] Add back link to pages without clear parent child relationships

### DIFF
--- a/components/composed/community/CommunityLayout/CommunityLayout.tsx
+++ b/components/composed/community/CommunityLayout/CommunityLayout.tsx
@@ -5,6 +5,7 @@ import { PageHeader, ContentSidebar, ContentHeader } from "components/layout";
 import { useChildRouteLinks, useMaybeFragment, useRouteSlug } from "hooks";
 import { RouteHelper } from "routes";
 import { useTranslation } from "react-i18next";
+
 export default function CommunityLayout({
   children,
   showSidebar = false,

--- a/components/composed/contributor/ContributorLayout/ContributorLayout.tsx
+++ b/components/composed/contributor/ContributorLayout/ContributorLayout.tsx
@@ -5,7 +5,12 @@ import type { ContributorLayoutFragment$key } from "@/relay/ContributorLayoutFra
 import { RouteHelper } from "routes";
 import { useTranslation } from "react-i18next";
 
-import { PageHeader, ContentSidebar, ContentHeader } from "components/layout";
+import {
+  PageHeader,
+  ContentSidebar,
+  ContentHeader,
+  BackToAll,
+} from "components/layout";
 import ContributorDisplayName from "../ContributorDisplayName";
 
 export default function ContributorLayout({
@@ -17,14 +22,15 @@ export default function ContributorLayout({
   data?: ContributorLayoutFragment$key | null;
   useRouteHeader?: boolean;
 }) {
+  const { t } = useTranslation();
   const slug = useRouteSlug() || undefined;
   const activeRoute = RouteHelper.activeRoute();
-  const { t } = useTranslation();
   const manageRoutes = useChildRouteLinks("contributor", { slug });
   const contributor = useMaybeFragment(fragment, data);
 
   return (
     <section>
+      <BackToAll route="contributors" />
       <PageHeader
         title={<ContributorDisplayName contributor={contributor} />}
       />

--- a/components/composed/user/UserLayout/UserLayout.tsx
+++ b/components/composed/user/UserLayout/UserLayout.tsx
@@ -1,5 +1,10 @@
 import React, { ReactNode } from "react";
-import { ContentSidebar, ContentHeader, PageHeader } from "components/layout";
+import {
+  ContentSidebar,
+  ContentHeader,
+  PageHeader,
+  BackToAll,
+} from "components/layout";
 import { useChildRouteLinks, useMaybeFragment, useRouteSlug } from "hooks";
 import { graphql } from "react-relay";
 import { RouteHelper } from "routes";
@@ -27,6 +32,7 @@ export default function UserLayout({
 
   return (
     <section>
+      <BackToAll route="users" />
       <PageHeader title={user?.name} />
       {showSidebar ? (
         <ContentSidebar sidebarLinks={manageRoutes}>

--- a/components/factories/IconFactory/IconFactory.tsx
+++ b/components/factories/IconFactory/IconFactory.tsx
@@ -29,6 +29,7 @@ export const ICON_MAP = {
 export const ICON_KEYS = Object.keys(ICON_MAP);
 
 export const SIZE_MAP = {
+  xs: 14,
   sm: 16,
   md: 24,
   lg: 32,

--- a/components/layout/BackToAll/BackToAll.stories.tsx
+++ b/components/layout/BackToAll/BackToAll.stories.tsx
@@ -1,0 +1,21 @@
+import { Story } from "@storybook/react";
+import BackToAll from ".";
+
+type Props = React.ComponentProps<typeof BackToAll>;
+
+export default {
+  title: "Components/Layout/BackToAll",
+  component: BackToAll,
+  parameters: {
+    themes: {
+      default: "neutral00",
+    },
+  },
+};
+
+const Template: Story<Props> = (args) => <BackToAll {...args} />;
+
+export const Default: Story<Props> = Template.bind({});
+Default.args = {
+  route: "communities",
+};

--- a/components/layout/BackToAll/BackToAll.styles.ts
+++ b/components/layout/BackToAll/BackToAll.styles.ts
@@ -1,0 +1,15 @@
+import styled from "styled-components";
+
+export const NavWrapper = styled.nav`
+  padding-block-start: 24px;
+`;
+
+export const LinkWrapper = styled.span`
+  display: flex;
+  align-items: center;
+  font-size: var(--font-size-sm);
+
+  > * + * {
+    margin-inline-start: 5px;
+  }
+`;

--- a/components/layout/BackToAll/BackToAll.tsx
+++ b/components/layout/BackToAll/BackToAll.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { useTranslation } from "react-i18next";
+import { IconFactory } from "components/factories";
+import { RouteHelper } from "routes";
+import { NamedLink } from "../../atomic";
+import * as Styled from "./BackToAll.styles";
+import { capitalize } from "lodash";
+
+interface Props {
+  route: string;
+}
+
+const BackBar = ({ route }: Props) => {
+  const { t } = useTranslation();
+  if (!route) return null;
+
+  const routeObj = RouteHelper.findRouteByName(route);
+  const name = capitalize(t(routeObj?.label || ""));
+
+  return (
+    <Styled.NavWrapper>
+      <NamedLink route={route} passHref>
+        <Styled.LinkWrapper as="a" className="a-link">
+          <IconFactory icon="arrow" rotate={270} size="xs" />
+          <span>{`${t("all")} ${t(name)}`}</span>
+        </Styled.LinkWrapper>
+      </NamedLink>
+    </Styled.NavWrapper>
+  );
+};
+
+export default BackBar;

--- a/components/layout/BackToAll/BackToAll.tsx
+++ b/components/layout/BackToAll/BackToAll.tsx
@@ -10,7 +10,7 @@ interface Props {
   route: string;
 }
 
-const BackBar = ({ route }: Props) => {
+const BackToAll = ({ route }: Props) => {
   const { t } = useTranslation();
   if (!route) return null;
 
@@ -29,4 +29,4 @@ const BackBar = ({ route }: Props) => {
   );
 };
 
-export default BackBar;
+export default BackToAll;

--- a/components/layout/BackToAll/index.ts
+++ b/components/layout/BackToAll/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./BackToAll";

--- a/components/layout/PageHeader/PageHeader.tsx
+++ b/components/layout/PageHeader/PageHeader.tsx
@@ -23,6 +23,7 @@ const PageHeader = ({
 }: Props) => {
   const activeRoute = RouteHelper.activeRoute();
   const { t } = useTranslation();
+
   return (
     <Styled.Header
       className={hideHeader ? "a-hidden" : ""}

--- a/components/layout/index.ts
+++ b/components/layout/index.ts
@@ -4,3 +4,4 @@ export { default as ContentSidebar } from "./ContentSidebar";
 export { default as Table } from "./Table";
 export { default as PageCountActions } from "./PageCountActions";
 export { default as ContentHeader } from "./ContentHeader";
+export { default as BackToAll } from "./BackToAll";

--- a/locales/en.json
+++ b/locales/en.json
@@ -15,6 +15,7 @@
     "edit": "Edit",
     "delete": "Delete",
     "loading": "Loading",
+    "all": "All",
     "site": {
       "title": "NGLP",
       "description": "...",

--- a/routes/baseRoutes.ts
+++ b/routes/baseRoutes.ts
@@ -8,6 +8,7 @@ export const baseRoutes: BaseRoute[] = [
   {
     name: "collections",
     path: "/collections",
+    label: "glossary.collection.label_plural",
     routes: [
       {
         name: "collection",
@@ -69,6 +70,7 @@ export const baseRoutes: BaseRoute[] = [
   {
     name: "items",
     path: "/items",
+    label: "glossary.item.label_plural",
     routes: [
       {
         name: "item",
@@ -130,6 +132,7 @@ export const baseRoutes: BaseRoute[] = [
   {
     name: "communities",
     path: "/communities",
+    label: "glossary.community.label_plural",
     routes: [
       {
         name: "community",
@@ -171,6 +174,7 @@ export const baseRoutes: BaseRoute[] = [
   {
     name: "users",
     path: "/users",
+    label: "glossary.user.label_plural",
     routes: [
       {
         name: "user",
@@ -204,6 +208,7 @@ export const baseRoutes: BaseRoute[] = [
   {
     name: "contributors",
     path: "/contributors",
+    label: "glossary.contributor.label_plural",
     routes: [
       {
         name: "contributor",


### PR DESCRIPTION
After discussing the problem with the FE team, the consensus was that it's OK to have both breadcrumbs on models with parent/child relationships and a "back" link on other models. Collections and Items are easy to get back to, as their link is provided in the main nav. (While "contributors" is hidden behind a dropdown).

Having just the text "Contributors" didn't seem like enough context for the user:
<img width="1075" alt="Screen Shot 2021-09-15 at 9 24 24 AM" src="https://user-images.githubusercontent.com/57107444/133491239-e784afd9-aa56-4eae-b761-f666a8aa5c62.png">

Adding an arrow and extra text seemed to help distinguish this back button from the parent/child breadcrumbs on other pages:
<img width="1100" alt="Screen Shot 2021-09-15 at 9 26 40 AM" src="https://user-images.githubusercontent.com/57107444/133491295-16b2850a-b717-4a59-ad9b-5e4232cb0702.png">

There's one more problem. If I land on a contributor page from an item or collection, going "Back to Contributors" doesn't make sense. It would make more sense to say "Back to [Item Name]". Unfortunately `next/router` does not provide a way to get the last route, so we don't really know what page we're going back to. 

Questions:
1. Is the above an actual problem? If so, does a link that just says ,"Back" work, or should we keep track of the last route?
2. Should the text read "All Contributors" instead of "Back to Contributors"?
3. Other opinions?