### PR TITLE
[F] Create Modal layout component

### DIFF
--- a/components/layout/Modal/Modal.stories.tsx
+++ b/components/layout/Modal/Modal.stories.tsx
@@ -1,7 +1,8 @@
 import Modal from "./Modal";
 import { Story } from "@storybook/react";
 import { useDialogState, DialogDisclosure } from "reakit/Dialog";
-import { ButtonControl } from "components/atomic/buttons";
+import { ButtonControl, Button } from "components/atomic/buttons";
+import { basePadding } from "theme/mixins/appearance";
 
 type Props = React.ComponentProps<typeof Modal>;
 
@@ -11,7 +12,7 @@ export default {
 };
 
 const Template: Story<Props> = (args) => {
-  const dialog = useDialogState({ visible: true, animated: false });
+  const dialog = useDialogState({ visible: true, animated: true });
   console.log(dialog);
 
   return (
@@ -24,9 +25,29 @@ const Template: Story<Props> = (args) => {
   );
 };
 
+const Content = () => (
+  <div>
+    <p className="t-copy-sm">
+      Description text for this modal window appears here, if necessary.
+      Description text for this modal window appears here, if necessary.
+    </p>
+    <div
+      style={{
+        display: "flex",
+        justifyContent: "space-between",
+        paddingBlockStart: basePadding(10),
+      }}
+    >
+      <Button style={{ paddingInline: basePadding(15) }}>Confirm</Button>
+      <Button secondary style={{ paddingInline: basePadding(17) }}>
+        Cancel
+      </Button>
+    </div>
+  </div>
+);
+
 export const Default = Template.bind({});
 Default.args = {
   label: "Modal title",
-  header: "Modal Header",
-  children: "Content",
+  children: <Content />,
 };

--- a/components/layout/Modal/Modal.stories.tsx
+++ b/components/layout/Modal/Modal.stories.tsx
@@ -59,6 +59,61 @@ const Content = ({ handleClose }: ContentProps) => {
   );
 };
 
+const ScrollContent = ({ handleClose }: ContentProps) => {
+  const isMobile = useIsMobile();
+  return (
+    <div>
+      <p className="t-copy-sm">
+        Description text for this modal window appears here, if necessary.
+        Description text for this modal window appears here, if necessary.
+      </p>
+      <br />
+      <p className="t-copy-sm">
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer nec
+        odio. Praesent libero. Sed cursus ante dapibus diam. Sed nisi. Nulla
+        quis sem at nibh elementum imperdiet. Duis sagittis ipsum. Praesent
+        mauris. Fusce nec tellus sed augue semper porta. Mauris massa.
+        Vestibulum lacinia arcu eget nulla. Class aptent taciti sociosqu ad
+        litora torquent per conubia nostra, per inceptos himenaeos. Curabitur
+        sodales ligula in libero.{" "}
+      </p>
+      <br />
+      <p className="t-copy-sm">
+        Sed dignissim lacinia nunc. Curabitur tortor. Pellentesque nibh. Aenean
+        quam. In scelerisque sem at dolor. Maecenas mattis. Sed convallis
+        tristique sem. Proin ut ligula vel nunc egestas porttitor. Morbi lectus
+        risus, iaculis vel, suscipit quis, luctus non, massa. Fusce ac turpis
+        quis ligula lacinia aliquet. Mauris ipsum. Nulla metus metus,
+        ullamcorper vel, tincidunt sed, euismod in, nibh. Quisque volutpat
+        condimentum velit.{" "}
+      </p>
+      <div
+        style={{
+          display: "flex",
+          flexDirection: isMobile ? "column" : "row",
+          justifyContent: "space-between",
+          paddingBlockStart: basePadding(10),
+          gap: "15px",
+        }}
+      >
+        <Button
+          style={{ paddingInline: basePadding(15) }}
+          onClick={handleClose}
+        >
+          Confirm
+        </Button>
+        <Button
+          secondary
+          style={{ paddingInline: basePadding(17) }}
+          onClick={handleClose}
+        >
+          Cancel
+        </Button>
+      </div>
+    </div>
+  );
+};
+
 interface ContentProps {
   handleClose: () => void;
 }
@@ -67,4 +122,10 @@ export const Default = Template.bind({});
 Default.args = {
   label: "Modal title",
   children: ({ handleClose }) => <Content handleClose={handleClose} />,
+};
+
+export const WithScrollingContent = Template.bind({});
+WithScrollingContent.args = {
+  label: "Modal title",
+  children: ({ handleClose }) => <ScrollContent handleClose={handleClose} />,
 };

--- a/components/layout/Modal/Modal.stories.tsx
+++ b/components/layout/Modal/Modal.stories.tsx
@@ -3,6 +3,7 @@ import { Story } from "@storybook/react";
 import { useDialogState, DialogDisclosure } from "reakit/Dialog";
 import { ButtonControl, Button } from "components/atomic/buttons";
 import { basePadding } from "theme/mixins/appearance";
+import { useIsMobile } from "hooks";
 
 type Props = React.ComponentProps<typeof Modal>;
 
@@ -25,26 +26,31 @@ const Template: Story<Props> = (args) => {
   );
 };
 
-const Content = () => (
-  <div>
-    <p className="t-copy-sm">
-      Description text for this modal window appears here, if necessary.
-      Description text for this modal window appears here, if necessary.
-    </p>
-    <div
-      style={{
-        display: "flex",
-        justifyContent: "space-between",
-        paddingBlockStart: basePadding(10),
-      }}
-    >
-      <Button style={{ paddingInline: basePadding(15) }}>Confirm</Button>
-      <Button secondary style={{ paddingInline: basePadding(17) }}>
-        Cancel
-      </Button>
+const Content = () => {
+  const isMobile = useIsMobile();
+  return (
+    <div>
+      <p className="t-copy-sm">
+        Description text for this modal window appears here, if necessary.
+        Description text for this modal window appears here, if necessary.
+      </p>
+      <div
+        style={{
+          display: "flex",
+          flexDirection: isMobile ? "column" : "row",
+          justifyContent: "space-between",
+          paddingBlockStart: basePadding(10),
+          gap: "15px",
+        }}
+      >
+        <Button style={{ paddingInline: basePadding(15) }}>Confirm</Button>
+        <Button secondary style={{ paddingInline: basePadding(17) }}>
+          Cancel
+        </Button>
+      </div>
     </div>
-  </div>
-);
+  );
+};
 
 export const Default = Template.bind({});
 Default.args = {

--- a/components/layout/Modal/Modal.stories.tsx
+++ b/components/layout/Modal/Modal.stories.tsx
@@ -14,8 +14,6 @@ export default {
 
 const Template: Story<Props> = (args) => {
   const dialog = useDialogState({ visible: true, animated: true });
-  console.log(dialog);
-
   return (
     <>
       <DialogDisclosure {...dialog}>
@@ -26,7 +24,7 @@ const Template: Story<Props> = (args) => {
   );
 };
 
-const Content = () => {
+const Content = ({ handleClose }: ContentProps) => {
   const isMobile = useIsMobile();
   return (
     <div>
@@ -43,8 +41,17 @@ const Content = () => {
           gap: "15px",
         }}
       >
-        <Button style={{ paddingInline: basePadding(15) }}>Confirm</Button>
-        <Button secondary style={{ paddingInline: basePadding(17) }}>
+        <Button
+          style={{ paddingInline: basePadding(15) }}
+          onClick={handleClose}
+        >
+          Confirm
+        </Button>
+        <Button
+          secondary
+          style={{ paddingInline: basePadding(17) }}
+          onClick={handleClose}
+        >
           Cancel
         </Button>
       </div>
@@ -52,8 +59,12 @@ const Content = () => {
   );
 };
 
+interface ContentProps {
+  handleClose: () => void;
+}
+
 export const Default = Template.bind({});
 Default.args = {
   label: "Modal title",
-  children: <Content />,
+  children: ({ handleClose }) => <Content handleClose={handleClose} />,
 };

--- a/components/layout/Modal/Modal.stories.tsx
+++ b/components/layout/Modal/Modal.stories.tsx
@@ -1,0 +1,32 @@
+import Modal from "./Modal";
+import { Story } from "@storybook/react";
+import { useDialogState, DialogDisclosure } from "reakit/Dialog";
+import { ButtonControl } from "components/atomic/buttons";
+
+type Props = React.ComponentProps<typeof Modal>;
+
+export default {
+  title: "Components/Layout/Modal",
+  component: Modal,
+};
+
+const Template: Story<Props> = (args) => {
+  const dialog = useDialogState({ visible: true, animated: false });
+  console.log(dialog);
+
+  return (
+    <>
+      <DialogDisclosure {...dialog}>
+        <ButtonControl as="span">Toggle Modal</ButtonControl>
+      </DialogDisclosure>
+      <Modal {...args} dialog={dialog} />
+    </>
+  );
+};
+
+export const Default = Template.bind({});
+Default.args = {
+  label: "Modal title",
+  header: "Modal Header",
+  children: "Content",
+};

--- a/components/layout/Modal/Modal.styles.ts
+++ b/components/layout/Modal/Modal.styles.ts
@@ -31,11 +31,13 @@ export const DialogBackdrop = styled(BaseDialogBackdrop)`
 export const Modal = styled(BaseDialog)`
   --modal-padding-inline: ${basePadding(10)};
   position: fixed;
-  top: 30px;
-  left: 40vw;
+  inset-block-start: 50%;
+  inset-inline-start: 50%;
+  transform: translate(-50%, -50%);
   display: flex;
   flex-direction: column;
-  max-width: ${pxToRem(497)};
+  width: ${pxToRem(497)};
+  max-width: 90%;
   overflow: auto;
   border: 1px solid var(--neutral10);
   border-radius: 6px;
@@ -44,19 +46,14 @@ export const Modal = styled(BaseDialog)`
 `;
 
 export const Header = styled.header`
-  padding-block-start: ${basePadding(10)};
-  padding-inline-start: var(--modal-padding-inline);
-  padding-inline-end: var(--modal-padding-inline);
+  padding-block: ${basePadding(10)};
+  padding-inline: var(--modal-padding-inline);
   background: var(--background-color);
-`;
-
-export const HeaderBar = styled.div`
   display: flex;
   flex-wrap: wrap;
   justify-content: space-between;
   align-items: center;
   color: var(--accent-color);
-  padding-block-end: ${basePadding(10)};
 `;
 
 export const Content = styled.div`

--- a/components/layout/Modal/Modal.styles.ts
+++ b/components/layout/Modal/Modal.styles.ts
@@ -1,0 +1,44 @@
+import styled from "styled-components";
+import { noInsetSupport } from "theme/mixins/base";
+import {
+  Dialog as BaseDialog,
+  DialogBackdrop as BaseDialogBackdrop,
+} from "reakit/Dialog";
+import { aBgLight, basePadding } from "theme/mixins/appearance";
+import { pxToRem } from "theme/mixins/functions";
+
+export const DialogBackdrop = styled(BaseDialogBackdrop)`
+  position: fixed;
+  background: var(--dialog-backdrop-background);
+  transition: opacity 0.1s var(--base-timing);
+  opacity: 0;
+  inset-block: 0;
+  inset-inline: 0;
+  z-index: var(--z-index-drawer-backdrop);
+
+  ${noInsetSupport(`
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+  `)}
+
+  &[data-enter] {
+    opacity: 1;
+  }
+`;
+
+export const Modal = styled(BaseDialog)`
+  --drawer-padding-inline: ${basePadding(12)};
+  position: fixed;
+  top: 10px;
+  left: 40vw;
+  display: flex;
+  flex-direction: column;
+  width: ${pxToRem(300)};
+  height: 200px;
+  overflow: auto;
+  border: 1px solid var(--neutral10);
+  z-index: var(--z-index-drawer);
+  ${aBgLight()}
+`;

--- a/components/layout/Modal/Modal.styles.ts
+++ b/components/layout/Modal/Modal.styles.ts
@@ -38,6 +38,8 @@ export const Modal = styled(BaseDialog)`
   flex-direction: column;
   width: ${pxToRem(497)};
   max-width: 90%;
+  height: ${pxToRem(312)};
+  max-height: 100%;
   overflow: auto;
   border: 1px solid var(--neutral10);
   border-radius: 6px;

--- a/components/layout/Modal/Modal.styles.ts
+++ b/components/layout/Modal/Modal.styles.ts
@@ -29,16 +29,39 @@ export const DialogBackdrop = styled(BaseDialogBackdrop)`
 `;
 
 export const Modal = styled(BaseDialog)`
-  --drawer-padding-inline: ${basePadding(12)};
+  --modal-padding-inline: ${basePadding(10)};
   position: fixed;
-  top: 10px;
+  top: 30px;
   left: 40vw;
   display: flex;
   flex-direction: column;
-  width: ${pxToRem(300)};
-  height: 200px;
+  max-width: ${pxToRem(497)};
   overflow: auto;
   border: 1px solid var(--neutral10);
+  border-radius: 6px;
   z-index: var(--z-index-drawer);
   ${aBgLight()}
+`;
+
+export const Header = styled.header`
+  padding-block-start: ${basePadding(10)};
+  padding-inline-start: var(--modal-padding-inline);
+  padding-inline-end: var(--modal-padding-inline);
+  background: var(--background-color);
+`;
+
+export const HeaderBar = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: center;
+  color: var(--accent-color);
+  padding-block-end: ${basePadding(10)};
+`;
+
+export const Content = styled.div`
+  flex: 1 1 auto;
+  padding-block-end: ${basePadding(12)};
+  padding-inline-start: var(--modal-padding-inline);
+  padding-inline-end: var(--modal-padding-inline);
 `;

--- a/components/layout/Modal/Modal.tsx
+++ b/components/layout/Modal/Modal.tsx
@@ -28,16 +28,14 @@ const Modal = ({
         {...dialog}
       >
         <Styled.Header>
-          <Styled.HeaderBar>
-            <div className="t-label-md" id={uidLabel}>
-              {label}
-            </div>
-            <ButtonControl icon="close" iconRotate={0} onClick={handleClose}>
-              {t("close")}
-            </ButtonControl>
-          </Styled.HeaderBar>
+          <div className="t-label-md" id={uidLabel}>
+            {label}
+          </div>
+          <ButtonControl icon="close" iconRotate={0} onClick={handleClose}>
+            {t("close")}
+          </ButtonControl>
         </Styled.Header>
-        <Styled.Content>{dialog.visible && children}</Styled.Content>
+        <Styled.Content>{children}</Styled.Content>
       </Styled.Modal>
     </Styled.DialogBackdrop>
   );

--- a/components/layout/Modal/Modal.tsx
+++ b/components/layout/Modal/Modal.tsx
@@ -35,18 +35,28 @@ const Modal = ({
             {t("close")}
           </ButtonControl>
         </Styled.Header>
-        <Styled.Content>{children}</Styled.Content>
+        <Styled.Content>
+          {typeof children === "function"
+            ? children({ handleClose })
+            : children}
+        </Styled.Content>
       </Styled.Modal>
     </Styled.DialogBackdrop>
   );
 };
+
+type RenderChildProps = {
+  handleClose: () => void;
+};
+
+type RenderChild = (props: RenderChildProps) => JSX.Element;
 
 interface Props {
   dialog: DialogProps;
   /** Modal label, displayed next to the close button */
   label: string;
   /** Modal content */
-  children?: JSX.Element | string | null;
+  children?: RenderChild | React.ReactNode;
   /** If false, disables hiding on click outside the drawer */
   hideOnClickOutside: boolean;
 }

--- a/components/layout/Modal/Modal.tsx
+++ b/components/layout/Modal/Modal.tsx
@@ -1,0 +1,59 @@
+import * as React from "react";
+import { useUID } from "react-uid";
+import { useTranslation } from "react-i18next";
+import { ButtonControl } from "components/atomic/buttons";
+import * as Styled from "./Modal.styles";
+import { DialogProps } from "reakit/Dialog";
+
+const Modal = ({
+  dialog,
+  label,
+  header,
+  children,
+  onClose,
+  hideOnClickOutside = true,
+}: Props) => {
+  const uidLabel = useUID();
+  const uidDesc = useUID();
+  const { t } = useTranslation();
+
+  const handleClose = () => {
+    if (dialog && dialog.hide) dialog.hide();
+    if (onClose) onClose();
+  };
+
+  return (
+    <Styled.DialogBackdrop>
+      <Styled.Modal
+        aria-labelledby={uidLabel}
+        aria-describedby={uidDesc}
+        hideOnClickOutside={hideOnClickOutside}
+      >
+        {label}
+        {header}
+        <ButtonControl icon="close" iconRotate={0} onClick={handleClose}>
+          {t("close")}
+        </ButtonControl>
+        {children}
+      </Styled.Modal>
+    </Styled.DialogBackdrop>
+  );
+};
+
+interface Props {
+  dialog: DialogProps;
+  /** Drawer label, displayed next to the close button */
+  label: string;
+  /** Drawer header */
+  header: string;
+  /** Drawer content */
+  children?: JSX.Element | string | null;
+  /** Adds a Save button to the drawer footer. Function runs on save */
+  onSave?: () => void;
+  /** Function runs on close or cancel */
+  onClose?: () => void;
+  /** If false, disables hiding on click outside the drawer */
+  hideOnClickOutside: boolean;
+}
+
+export default Modal;

--- a/components/layout/Modal/Modal.tsx
+++ b/components/layout/Modal/Modal.tsx
@@ -8,9 +8,7 @@ import { DialogProps } from "reakit/Dialog";
 const Modal = ({
   dialog,
   label,
-  header,
   children,
-  onClose,
   hideOnClickOutside = true,
 }: Props) => {
   const uidLabel = useUID();
@@ -19,22 +17,27 @@ const Modal = ({
 
   const handleClose = () => {
     if (dialog && dialog.hide) dialog.hide();
-    if (onClose) onClose();
   };
 
   return (
-    <Styled.DialogBackdrop>
+    <Styled.DialogBackdrop {...dialog}>
       <Styled.Modal
         aria-labelledby={uidLabel}
         aria-describedby={uidDesc}
         hideOnClickOutside={hideOnClickOutside}
+        {...dialog}
       >
-        {label}
-        {header}
-        <ButtonControl icon="close" iconRotate={0} onClick={handleClose}>
-          {t("close")}
-        </ButtonControl>
-        {children}
+        <Styled.Header>
+          <Styled.HeaderBar>
+            <div className="t-label-md" id={uidLabel}>
+              {label}
+            </div>
+            <ButtonControl icon="close" iconRotate={0} onClick={handleClose}>
+              {t("close")}
+            </ButtonControl>
+          </Styled.HeaderBar>
+        </Styled.Header>
+        <Styled.Content>{dialog.visible && children}</Styled.Content>
       </Styled.Modal>
     </Styled.DialogBackdrop>
   );
@@ -42,16 +45,10 @@ const Modal = ({
 
 interface Props {
   dialog: DialogProps;
-  /** Drawer label, displayed next to the close button */
+  /** Modal label, displayed next to the close button */
   label: string;
-  /** Drawer header */
-  header: string;
-  /** Drawer content */
+  /** Modal content */
   children?: JSX.Element | string | null;
-  /** Adds a Save button to the drawer footer. Function runs on save */
-  onSave?: () => void;
-  /** Function runs on close or cancel */
-  onClose?: () => void;
   /** If false, disables hiding on click outside the drawer */
   hideOnClickOutside: boolean;
 }

--- a/components/layout/Modal/index.ts
+++ b/components/layout/Modal/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./Modal";


### PR DESCRIPTION
This Modal component is based largely off Drawer. It includes a simplified header and the remainder of its content is rendered in its children. Eventually, `dialog.hide` will need to be passed to the children so buttons can close the modal.