### PR TITLE
[F] Add drawer option to ButtonControlGroup 

### DIFF
--- a/components/atomic/buttons/ButtonControl/index.ts
+++ b/components/atomic/buttons/ButtonControl/index.ts
@@ -1,3 +1,5 @@
 import ButtonControl from "./ButtonControl";
+import ButtonControlDrawer from "./patterns/ButtonControlDrawer";
 
 export default ButtonControl;
+export { ButtonControlDrawer };

--- a/components/atomic/buttons/ButtonControl/patterns/ButtonControlDrawer.stories.tsx
+++ b/components/atomic/buttons/ButtonControl/patterns/ButtonControlDrawer.stories.tsx
@@ -1,0 +1,63 @@
+import ButtonControlDrawer from "./ButtonControlDrawer";
+import { Story } from "@storybook/react";
+import { ICON_KEYS } from "components/factories/IconFactory";
+import { withDesign } from "storybook-addon-designs";
+type BaseProps = React.ComponentProps<typeof ButtonControlDrawer>;
+
+export default {
+  title: "Components/Atomic/Buttons/ButtonControlDrawer",
+  component: ButtonControlDrawer,
+  decorators: [withDesign],
+  parameters: {
+    themes: {
+      default: "neutral00",
+    },
+    design: [
+      {
+        type: "figma",
+        url:
+          "https://www.figma.com/file/EeaBT8NWvguKGhMQ7pgpry/NGLP-Admin-UI-Design?node-id=29%3A163",
+      },
+      {
+        type: "figma",
+        url:
+          "https://www.figma.com/file/EeaBT8NWvguKGhMQ7pgpry/NGLP-Admin-UI-Design?node-id=29%3A157",
+      },
+      {
+        type: "figma",
+        url:
+          "https://www.figma.com/file/EeaBT8NWvguKGhMQ7pgpry/NGLP-Admin-UI-Design?node-id=38%3A240",
+      },
+    ],
+  },
+  argTypes: {
+    icon: {
+      options: [null, ...ICON_KEYS],
+      control: { type: "select" },
+    },
+    size: {
+      options: ["default", "large"],
+      control: { type: "select" },
+    },
+  },
+};
+
+interface Props extends BaseProps {
+  disabled: boolean;
+  text: string;
+  href: string;
+  "aria-label"?: string;
+}
+
+const Template: Story<Props> = ({ text, ...args }) => (
+  <ButtonControlDrawer {...args}>{text}</ButtonControlDrawer>
+);
+
+export const Default: Story<Props> = Template.bind({});
+
+Default.args = {
+  text: "Example Add Button",
+  icon: "plus",
+  drawer: "addPerson",
+  disabled: false,
+};

--- a/components/atomic/buttons/ButtonControl/patterns/ButtonControlDrawer.tsx
+++ b/components/atomic/buttons/ButtonControl/patterns/ButtonControlDrawer.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { forwardRef } from "react";
 import { DrawerLink, ButtonControl } from "components/atomic";
 type BaseProps = React.ComponentProps<typeof ButtonControl>;
 type DrawerLinkProps = React.ComponentProps<typeof DrawerLink>;
@@ -6,16 +6,20 @@ type DrawerLinkProps = React.ComponentProps<typeof DrawerLink>;
 /**
  * A button control that opens a drawer
  */
-const ButtonControlDrawer = ({ drawer, icon, children }: Props) => {
-  return (
-    <DrawerLink drawer={drawer} passHref>
-      <ButtonControl as="a" icon={icon}>
-        {children}
-      </ButtonControl>
-    </DrawerLink>
-  );
-};
+const ButtonControlDrawer = forwardRef(
+  ({ drawer, icon, children }: Props, ref) => {
+    return (
+      <DrawerLink drawer={drawer} passHref>
+        <ButtonControl as="a" icon={icon} ref={ref}>
+          {children}
+        </ButtonControl>
+      </DrawerLink>
+    );
+  }
+);
 
-type Props = BaseProps & Pick<DrawerLinkProps, "drawer">;
+interface Props extends BaseProps {
+  drawer: DrawerLinkProps["drawer"];
+}
 
 export default ButtonControlDrawer;

--- a/components/atomic/buttons/ButtonControl/patterns/ButtonControlDrawer.tsx
+++ b/components/atomic/buttons/ButtonControl/patterns/ButtonControlDrawer.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+import { DrawerLink, ButtonControl } from "components/atomic";
+type BaseProps = React.ComponentProps<typeof ButtonControl>;
+type DrawerLinkProps = React.ComponentProps<typeof DrawerLink>;
+
+/**
+ * A button control that opens a drawer
+ */
+const ButtonControlDrawer = ({ drawer, icon, children }: Props) => {
+  return (
+    <DrawerLink drawer={drawer} passHref>
+      <ButtonControl as="a" icon={icon}>
+        {children}
+      </ButtonControl>
+    </DrawerLink>
+  );
+};
+
+type Props = BaseProps & Pick<DrawerLinkProps, "drawer">;
+
+export default ButtonControlDrawer;

--- a/components/atomic/buttons/ButtonControlGroup/ButtonControlGroup.stories.tsx
+++ b/components/atomic/buttons/ButtonControlGroup/ButtonControlGroup.stories.tsx
@@ -36,6 +36,11 @@ Default.args = {
   toggleLabel: "Options",
   buttons: [
     {
+      children: "Add",
+      drawer: "addPerson",
+      icon: "plus",
+    },
+    {
       children: "Edit",
       icon: "edit",
     },
@@ -52,16 +57,23 @@ WithAuthActions.args = {
   toggleLabel: "Options",
   buttons: [
     {
+      children: "Add",
+      drawer: "addPerson",
+      icon: "plus",
+      actions: "self.add",
+      allowedActions: ["self.edit", "self.add"],
+    },
+    {
       children: "Edit",
       icon: "edit",
       actions: "self.edit",
-      allowedActions: ["self.edit"],
+      allowedActions: ["self.edit", "self.add"],
     },
     {
       children: "Delete",
       icon: "delete",
       actions: "self.delete",
-      allowedActions: ["self.edit"],
+      allowedActions: ["self.edit", "self.add"],
     },
   ],
 };

--- a/components/atomic/buttons/ButtonControlGroup/ButtonControlGroup.tsx
+++ b/components/atomic/buttons/ButtonControlGroup/ButtonControlGroup.tsx
@@ -6,8 +6,9 @@ import {
 } from "components/atomic";
 import * as Styled from "./ButtonControlGroup.styles";
 
-type ButtonProps = React.ComponentProps<typeof ButtonControl> &
-  React.ComponentProps<typeof ButtonControlDrawer>;
+type ButtonProps =
+  | React.ComponentProps<typeof ButtonControl>
+  | React.ComponentProps<typeof ButtonControlDrawer>;
 
 function ButtonControlGroup({
   buttons,
@@ -17,10 +18,10 @@ function ButtonControlGroup({
   toggleText,
 }: Props) {
   function renderButton(props: ButtonProps, i: number) {
-    const { children, drawer, ...buttonProps } = props;
+    const { children, ...buttonProps } = props;
 
-    return drawer ? (
-      <ButtonControlDrawer key={i} drawer={drawer} {...buttonProps}>
+    return "drawer" in props ? (
+      <ButtonControlDrawer key={i} drawer={props.drawer} {...buttonProps}>
         {children}
       </ButtonControlDrawer>
     ) : (

--- a/components/atomic/buttons/ButtonControlGroup/ButtonControlGroup.tsx
+++ b/components/atomic/buttons/ButtonControlGroup/ButtonControlGroup.tsx
@@ -1,8 +1,13 @@
 import React from "react";
-import { ButtonControl, Dropdown } from "components/atomic";
+import {
+  ButtonControl,
+  ButtonControlDrawer,
+  Dropdown,
+} from "components/atomic";
 import * as Styled from "./ButtonControlGroup.styles";
 
-type ButtonProps = React.ComponentProps<typeof ButtonControl>;
+type ButtonProps = React.ComponentProps<typeof ButtonControl> &
+  React.ComponentProps<typeof ButtonControlDrawer>;
 
 function ButtonControlGroup({
   buttons,
@@ -12,9 +17,13 @@ function ButtonControlGroup({
   toggleText,
 }: Props) {
   function renderButton(props: ButtonProps, i: number) {
-    const { children, ...buttonProps } = props;
+    const { children, drawer, ...buttonProps } = props;
 
-    return (
+    return drawer ? (
+      <ButtonControlDrawer key={i} drawer={drawer} {...buttonProps}>
+        {children}
+      </ButtonControlDrawer>
+    ) : (
       <ButtonControl key={i} {...buttonProps}>
         {children}
       </ButtonControl>

--- a/components/atomic/buttons/index.ts
+++ b/components/atomic/buttons/index.ts
@@ -1,3 +1,3 @@
 export { default as Button } from "./Button";
-export { default as ButtonControl } from "./ButtonControl";
+export { default as ButtonControl, ButtonControlDrawer } from "./ButtonControl";
 export { default as ButtonControlGroup } from "./ButtonControlGroup";

--- a/components/composed/contributor/ContributorList/ContributorList.tsx
+++ b/components/composed/contributor/ContributorList/ContributorList.tsx
@@ -12,7 +12,7 @@ import { useMaybeFragment, useDestroyer, useDrawerHelper } from "hooks";
 
 import ModelColumns from "components/composed/model/ModelColumns";
 import { DataViewOptions } from "components/atomic/DataViewToggle";
-import { DrawerLink, ButtonControl } from "components/atomic";
+import { ButtonControlGroup } from "components/atomic";
 import { getContributorDisplayName } from "../ContributorDisplayName";
 import PageHeader from "components/layout/PageHeader";
 
@@ -62,18 +62,22 @@ function ContributorList<T extends OperationType>({
   // TODO: We need an authorization check here. The contributors.create check doesn't
   //  exist yet in the API.
   const buttons = (
-    <div className="l-flex l-flex--gap">
-      <DrawerLink drawer="addPerson" passHref>
-        <ButtonControl as="a" icon="plus">
-          {t("actions.create.contributor.person")}
-        </ButtonControl>
-      </DrawerLink>
-      <DrawerLink drawer="addOrganization" passHref>
-        <ButtonControl as="a" icon="plus">
-          {t("actions.create.contributor.organization")}
-        </ButtonControl>
-      </DrawerLink>
-    </div>
+    <ButtonControlGroup
+      buttons={[
+        {
+          drawer: "addPerson",
+          icon: "plus",
+          children: t("actions.create.contributor.person"),
+        },
+        {
+          drawer: "addOrganization",
+          icon: "plus",
+          children: t("actions.create.contributor.organization"),
+        },
+      ]}
+      toggleLabel={t("options")}
+      menuLabel={t("options")}
+    />
   );
 
   return (

--- a/components/global/Header/HeaderNavLinks.tsx
+++ b/components/global/Header/HeaderNavLinks.tsx
@@ -44,7 +44,9 @@ function HeaderNavLinks({ navigation }: Props) {
 
   const renderDropdown = (item: HeaderNavParent) => {
     // Check if the disclosure should be active
-    const active = RouteHelper.isRouteNameFuzzyActive(item.route || "");
+    const active = item?.children?.some((item) => {
+      return RouteHelper.isRouteNameFuzzyActive(item.route);
+    });
 
     return (
       <Dropdown


### PR DESCRIPTION
Created a new ButtonControl pattern called ButtonControlDrawer. As the name suggestions, this is a button control that opens a drawer! Creating a pattern made it easer to add the drawer flag to the ButtonControlGroup.

For everyone's sake, here's the difference between each control:
* ButtonControl - A styled button. Can be a link if `as='link'` prop is passed
* ButtonControlDrawer - A button control that opens a drawer. Uses DrawerLink and ButtonControl under the hood.
* ButtonControlGroup - Pass in an array of button props, and this spits out a list of button controls. On mobile, the controls are in a dropdown menu.