### PR TITLE
[POC] Translation cleanup

### DIFF
--- a/components/atomic/navs/MobileSubNav/MobileSubNav.stories.tsx
+++ b/components/atomic/navs/MobileSubNav/MobileSubNav.stories.tsx
@@ -43,11 +43,11 @@ const LINKS = [
 const TABS = [
   {
     route: "collection.child.collections",
-    label: "glossary.collection.label_plural",
+    label: "glossary.collection_plural",
   },
   {
     route: "collection.child.items",
-    label: "glossary.item.label_plural",
+    label: "glossary.item_plural",
   },
   {
     route: "collection.manage",

--- a/components/atomic/navs/TabNav/TabNav.stories.tsx
+++ b/components/atomic/navs/TabNav/TabNav.stories.tsx
@@ -21,11 +21,11 @@ Default.args = {
   links: [
     {
       route: "collection.child.collections",
-      label: "glossary.collection.label_plural",
+      label: "glossary.collection_plural",
     },
     {
       route: "collection.child.items",
-      label: "glossary.item.label_plural",
+      label: "glossary.item_plural",
     },
     {
       route: "collection.manage",

--- a/components/composed/collection/CollectionUpdateForm/CollectionUpdateForm.tsx
+++ b/components/composed/collection/CollectionUpdateForm/CollectionUpdateForm.tsx
@@ -51,22 +51,19 @@ export default function CollectionUpdateForm({
     ({ form: { register, watch } }) => (
       <Forms.Grid>
         <Forms.Input
-          label="forms.collection.fields.title"
+          label="forms.fields.title"
           isWide
           {...register("title")}
         />
         <Forms.FileUpload
-          label="forms.collection.fields.thumbnail"
+          label="forms.fields.thumbnail"
           name="thumbnail"
           image={thumbnail?.thumb}
           clearName="clearThumbnail"
         />
-        <Forms.Textarea
-          label="forms.collection.fields.summary"
-          {...register("summary")}
-        />
+        <Forms.Textarea label="forms.fields.summary" {...register("summary")} />
         <Forms.Select
-          label="forms.collection.fields.visibility"
+          label="forms.fields.visibility"
           options={[
             { label: "Visible", value: "VISIBLE" },
             { label: "Hidden", value: "HIDDEN" },
@@ -77,13 +74,13 @@ export default function CollectionUpdateForm({
         />
         <Forms.HiddenField watch={watch} field="visibility" showOn="LIMITED">
           <Forms.Datepicker
-            label="forms.collection.fields.visibleAfterAt"
+            label="forms.fields.visibleAfterAt"
             {...register("visibleAfterAt")}
           />
         </Forms.HiddenField>
         <Forms.HiddenField watch={watch} field="visibility" showOn="LIMITED">
           <Forms.Datepicker
-            label="forms.collection.fields.visibleUntilAt"
+            label="forms.fields.visibleUntilAt"
             {...register("visibleUntilAt")}
           />
         </Forms.HiddenField>

--- a/components/composed/collection/CollectionUpdateForm/CollectionUpdateForm.tsx
+++ b/components/composed/collection/CollectionUpdateForm/CollectionUpdateForm.tsx
@@ -50,11 +50,7 @@ export default function CollectionUpdateForm({
   const renderForm = useRenderForm<Fields>(
     ({ form: { register, watch } }) => (
       <Forms.Grid>
-        <Forms.Input
-          label="forms.fields.title"
-          isWide
-          {...register("title")}
-        />
+        <Forms.Input label="forms.fields.title" isWide {...register("title")} />
         <Forms.FileUpload
           label="forms.fields.thumbnail"
           name="thumbnail"

--- a/components/composed/community/CommunityCreateForm/CommunityCreateForm.tsx
+++ b/components/composed/community/CommunityCreateForm/CommunityCreateForm.tsx
@@ -16,10 +16,7 @@ export default function CommunityCreateForm({ onSuccess }: Props) {
   const renderForm = useRenderForm<Fields>(
     ({ form: { register } }) => (
       <Forms.Grid>
-        <Forms.Input
-          label="forms.community.fields.title"
-          {...register("title")}
-        />
+        <Forms.Input label="forms.fields.title" {...register("title")} />
       </Forms.Grid>
     ),
     []

--- a/components/composed/community/CommunityUpdateForm/CommunityUpdateForm.tsx
+++ b/components/composed/community/CommunityUpdateForm/CommunityUpdateForm.tsx
@@ -36,10 +36,7 @@ export default function CommunityUpdateForm({
   const renderForm = useRenderForm<Fields>(
     ({ form: { register } }) => (
       <Forms.Grid>
-        <Forms.Input
-          label="forms.community.fields.title"
-          {...register("title")}
-        />
+        <Forms.Input label="forms.fields.title" {...register("title")} />
       </Forms.Grid>
     ),
     []

--- a/components/composed/contribution/CollectionContributionList/CollectionContributionList.tsx
+++ b/components/composed/contribution/CollectionContributionList/CollectionContributionList.tsx
@@ -104,7 +104,7 @@ function CollectionContributionList<T extends OperationType>({
     }: ModelTableActionProps<CollectionContributionNode>) =>
       destroy.contribution(
         { contributionId: row.original.id },
-        "glossary.contribution.label"
+        "glossary.contribution"
       ),
   };
 

--- a/components/composed/contribution/ContributionCreateForm/ContributionCreateForm.tsx
+++ b/components/composed/contribution/ContributionCreateForm/ContributionCreateForm.tsx
@@ -30,20 +30,16 @@ export default function ContributionCreateForm({
         <Forms.ContributorTypeahead<Fields>
           control={control}
           name="contributorId"
-          label="forms.contribution.fields.contributor"
+          label="forms.fields.contributor"
           required
         />
         <Forms.Input
           name=""
-          label="forms.contribution.fields.object"
+          label="forms.fields.object"
           disabled
           defaultValue={contributableName}
         />
-        <Forms.Input
-          label="forms.contribution.fields.role"
-          required
-          {...register("role")}
-        />
+        <Forms.Input label="forms.fields.role" required {...register("role")} />
       </Forms.Grid>
     ),
     []

--- a/components/composed/contribution/ContributionUpdateForm/ContributionUpdateForm.tsx
+++ b/components/composed/contribution/ContributionUpdateForm/ContributionUpdateForm.tsx
@@ -26,14 +26,14 @@ export default function ContributionUpdateForm({
   );
 
   let title = "";
-  let objectLabel = "forms.contribution.fields.object";
+  let objectLabel = "forms.fields.object";
   switch (maybeContribution.__typename) {
     case "ItemContribution":
-      objectLabel = "forms.contribution.fields.item";
+      objectLabel = "forms.fields.item";
       title = maybeContribution.item.title || "";
       break;
     case "CollectionContribution":
-      objectLabel = "forms.contribution.fields.collection";
+      objectLabel = "forms.fields.collection";
       title = maybeContribution.collection.title || "";
       break;
   }
@@ -61,7 +61,7 @@ export default function ContributionUpdateForm({
       <Forms.Grid>
         <Forms.Input
           name=""
-          label="forms.contribution.fields.contributor"
+          label="forms.fields.contributor"
           disabled
           defaultValue={getContributorDisplayName(
             maybeContribution.__typename !== "%other"
@@ -75,10 +75,7 @@ export default function ContributionUpdateForm({
           disabled
           defaultValue={title}
         />
-        <Forms.Input
-          label="forms.contribution.fields.role"
-          {...register("role")}
-        />
+        <Forms.Input label="forms.fields.role" {...register("role")} />
       </Forms.Grid>
     ),
     []

--- a/components/composed/contribution/ItemContributionList/ItemContributionList.tsx
+++ b/components/composed/contribution/ItemContributionList/ItemContributionList.tsx
@@ -93,7 +93,7 @@ function ItemContributionList<T extends OperationType>({
     handleDelete: ({ row }: ModelTableActionProps<ItemContributionNode>) =>
       destroy.contribution(
         { contributionId: row.original.id },
-        "glossary.contribution.label"
+        "glossary.contribution"
       ),
   };
 

--- a/components/composed/contributor/ContributorCreateOrganizationForm/ContributorCreateOrganizationForm.tsx
+++ b/components/composed/contributor/ContributorCreateOrganizationForm/ContributorCreateOrganizationForm.tsx
@@ -20,30 +20,21 @@ export default function ContributorCreateOrganizationForm({
     ({ form: { register, control } }) => (
       <Forms.Grid>
         <Forms.Input
-          label="forms.contributor.fields.legalName"
+          label="forms.fields.legalName"
           {...register("legalName")}
         />
         <Forms.Email
-          label="forms.contributor.fields.email"
+          label="forms.fields.email"
           {...register("email")}
           description="Format: example@email.com"
         />
-        <Forms.FileUpload label="forms.contributor.fields.image" name="image" />
-        <Forms.Input
-          label="forms.contributor.fields.location"
-          {...register("location")}
-        />
-        <Forms.Textarea
-          label="forms.contributor.fields.bio"
-          {...register("bio")}
-        />
-        <Forms.Input
-          label="forms.contributor.fields.url"
-          {...register("url")}
-        />
+        <Forms.FileUpload label="forms.fields.image" name="image" />
+        <Forms.Input label="forms.fields.location" {...register("location")} />
+        <Forms.Textarea label="forms.fields.bio" {...register("bio")} />
+        <Forms.Input label="forms.fields.url" {...register("url")} />
         <Forms.LinksRepeater<Fields>
-          label="forms.contributor.fields.links"
-          itemLabel="forms.contributor.fields.link"
+          label="forms.fields.links"
+          itemLabel="forms.fields.link"
           name="links"
           register={register}
           control={control}

--- a/components/composed/contributor/ContributorCreatePersonForm/ContributorCreatePersonForm.tsx
+++ b/components/composed/contributor/ContributorCreatePersonForm/ContributorCreatePersonForm.tsx
@@ -20,34 +20,28 @@ export default function ContributorCreatePersonForm({
     ({ form: { register, control } }) => (
       <Forms.Grid>
         <Forms.Input
-          label="forms.contributor.fields.givenName"
+          label="forms.fields.givenName"
           {...register("givenName")}
         />
         <Forms.Input
-          label="forms.contributor.fields.familyName"
+          label="forms.fields.familyName"
           {...register("familyName")}
         />
-        <Forms.FileUpload label="forms.contributor.fields.image" name="image" />
-        <Forms.Input
-          label="forms.contributor.fields.title"
-          {...register("title")}
-        />
+        <Forms.FileUpload label="forms.fields.image" name="image" />
+        <Forms.Input label="forms.fields.title" {...register("title")} />
         <Forms.Email
-          label="forms.contributor.fields.email"
+          label="forms.fields.email"
           {...register("email")}
           description="Format: example@email.com"
         />
         <Forms.Input
-          label="forms.contributor.fields.affiliation"
+          label="forms.fields.affiliation"
           {...register("affiliation")}
         />
-        <Forms.Textarea
-          label="forms.contributor.fields.bio"
-          {...register("bio")}
-        />
+        <Forms.Textarea label="forms.fields.bio" {...register("bio")} />
         <Forms.LinksRepeater<Fields>
-          label="forms.contributor.fields.links"
-          itemLabel="forms.contributor.fields.link"
+          label="forms.fields.links"
+          itemLabel="forms.fields.link"
           name="links"
           register={register}
           control={control}

--- a/components/composed/contributor/ContributorUpdateOrganizationForm/ContributorUpdateOrganizationForm.tsx
+++ b/components/composed/contributor/ContributorUpdateOrganizationForm/ContributorUpdateOrganizationForm.tsx
@@ -46,35 +46,26 @@ export default function ContributorUpdateOrganizationForm({
     ({ form: { register, control } }) => (
       <Forms.Grid>
         <Forms.Input
-          label="forms.contributor.fields.legalName"
+          label="forms.fields.legalName"
           {...register("legalName")}
         />
         <Forms.Email
-          label="forms.contributor.fields.email"
+          label="forms.fields.email"
           {...register("email")}
           description="Format: example@email.com"
         />
         <Forms.FileUpload
-          label="forms.contributor.fields.image"
+          label="forms.fields.image"
           name="image"
           image={image?.thumb}
           clearName="clearImage"
         />
-        <Forms.Input
-          label="forms.contributor.fields.location"
-          {...register("location")}
-        />
-        <Forms.Textarea
-          label="forms.contributor.fields.bio"
-          {...register("bio")}
-        />
-        <Forms.Input
-          label="forms.contributor.fields.url"
-          {...register("url")}
-        />
+        <Forms.Input label="forms.fields.location" {...register("location")} />
+        <Forms.Textarea label="forms.fields.bio" {...register("bio")} />
+        <Forms.Input label="forms.fields.url" {...register("url")} />
         <Forms.LinksRepeater
-          label="forms.contributor.fields.links"
-          itemLabel="forms.contributor.fields.link"
+          label="forms.fields.links"
+          itemLabel="forms.fields.link"
           name="links"
           register={register}
           control={control}

--- a/components/composed/contributor/ContributorUpdatePersonForm/ContributorUpdatePersonForm.tsx
+++ b/components/composed/contributor/ContributorUpdatePersonForm/ContributorUpdatePersonForm.tsx
@@ -74,11 +74,7 @@ export default function ContributorUpdatePersonForm({
           image={image?.thumb}
           clearName="clearImage"
         />
-        <Forms.Textarea
-          label="forms.fields.bio"
-          isWide
-          {...register("bio")}
-        />
+        <Forms.Textarea label="forms.fields.bio" isWide {...register("bio")} />
         <Forms.LinksRepeater
           label="forms.fields.links"
           itemLabel="forms.fields.link"

--- a/components/composed/contributor/ContributorUpdatePersonForm/ContributorUpdatePersonForm.tsx
+++ b/components/composed/contributor/ContributorUpdatePersonForm/ContributorUpdatePersonForm.tsx
@@ -49,39 +49,39 @@ export default function ContributorUpdatePersonForm({
     ({ form: { register, control } }) => (
       <Forms.Grid>
         <Forms.Input
-          label="forms.contributor.fields.givenName"
+          label="forms.fields.givenName"
           {...register("givenName")}
           required
         />
         <Forms.Input
-          label="forms.contributor.fields.familyName"
+          label="forms.fields.familyName"
           {...register("familyName")}
           required
         />
         <Forms.Input label="Title" {...register("title")} />
         <Forms.Input
-          label="forms.contributor.fields.affiliation"
+          label="forms.fields.affiliation"
           {...register("affiliation")}
         />
         <Forms.Email
-          label="forms.contributor.fields.email"
+          label="forms.fields.email"
           description="Format: example@email.com"
           {...register("email")}
         />
         <Forms.FileUpload
-          label="forms.contributor.fields.image"
+          label="forms.fields.image"
           name="image"
           image={image?.thumb}
           clearName="clearImage"
         />
         <Forms.Textarea
-          label="forms.contributor.fields.bio"
+          label="forms.fields.bio"
           isWide
           {...register("bio")}
         />
         <Forms.LinksRepeater
-          label="forms.contributor.fields.links"
-          itemLabel="forms.contributor.fields.link"
+          label="forms.fields.links"
+          itemLabel="forms.fields.link"
           name="links"
           register={register}
           control={control}

--- a/components/composed/file/FileList/FileList.tsx
+++ b/components/composed/file/FileList/FileList.tsx
@@ -55,7 +55,7 @@ function FileList<T extends OperationType>({
   //   handleEdit: ({ row }: ModelTableActionProps<FileNode>) =>
   //     drawerHelper.open("editFile", { drawerSlug: row.original.slug }),
   //   handleDelete: ({ row }: ModelTableActionProps<FileNode>) =>
-  //     destroy.file({ fileId: row.id }, "glossary.file.label"),
+  //     destroy.file({ fileId: row.id }, "glossary.file"),
   // };
 
   // TODO: We need an authorization check here.

--- a/components/composed/item/ItemUpdateForm/ItemUpdateForm.tsx
+++ b/components/composed/item/ItemUpdateForm/ItemUpdateForm.tsx
@@ -47,11 +47,7 @@ export default function ItemUpdateForm({
   const renderForm = useRenderForm<Fields>(
     ({ form: { register, watch } }) => (
       <Forms.Grid>
-        <Forms.Input
-          label="forms.fields.title"
-          {...register("title")}
-          isWide
-        />
+        <Forms.Input label="forms.fields.title" {...register("title")} isWide />
         <Forms.FileUpload
           label="forms.fields.thumbnail"
           name="thumbnail"

--- a/components/composed/item/ItemUpdateForm/ItemUpdateForm.tsx
+++ b/components/composed/item/ItemUpdateForm/ItemUpdateForm.tsx
@@ -48,22 +48,19 @@ export default function ItemUpdateForm({
     ({ form: { register, watch } }) => (
       <Forms.Grid>
         <Forms.Input
-          label="forms.item.fields.title"
+          label="forms.fields.title"
           {...register("title")}
           isWide
         />
         <Forms.FileUpload
-          label="forms.item.fields.thumbnail"
+          label="forms.fields.thumbnail"
           name="thumbnail"
           image={thumbnail?.thumb}
           clearName="clearThumbnail"
         />
-        <Forms.Textarea
-          label="forms.item.fields.summary"
-          {...register("summary")}
-        />
+        <Forms.Textarea label="forms.fields.summary" {...register("summary")} />
         <Forms.Select
-          label="forms.item.fields.visibility"
+          label="forms.fields.visibility"
           options={[
             { label: "Visible", value: "VISIBLE" },
             { label: "Hidden", value: "HIDDEN" },
@@ -74,13 +71,13 @@ export default function ItemUpdateForm({
         />
         <Forms.HiddenField watch={watch} field="visibility" showOn="LIMITED">
           <Forms.Datepicker
-            label="forms.item.fields.visibleAfterAt"
+            label="forms.fields.visibleAfterAt"
             {...register("visibleAfterAt")}
           />
         </Forms.HiddenField>
         <Forms.HiddenField watch={watch} field="visibility" showOn="LIMITED">
           <Forms.Datepicker
-            label="forms.item.fields.visibleUntilAt"
+            label="forms.fields.visibleUntilAt"
             {...register("visibleUntilAt")}
           />
         </Forms.HiddenField>

--- a/components/composed/model/ModelListHeader/ModelListHeader.tsx
+++ b/components/composed/model/ModelListHeader/ModelListHeader.tsx
@@ -20,7 +20,7 @@ function ModelListHeader({
   hideHeader,
 }: ModelHeaderProps) {
   const { t } = useTranslation();
-  const title = modelName ? t(`glossary.${modelName}.label`, { count: 2 }) : "";
+  const title = modelName ? t(`glossary.${modelName}`, { count: 2 }) : "";
 
   let renderButtons;
   if (buttons) {

--- a/components/forms/LinksRepeater/LinksRepeater.tsx
+++ b/components/forms/LinksRepeater/LinksRepeater.tsx
@@ -36,7 +36,7 @@ function LinksRepeater<T extends FieldValues = FieldValues>({
         <Fieldset.Fields key={field.id}>
           <Fieldset.Field>
             <Forms.Input
-              label="forms.inputs.linkRepeater.fields.title"
+              label="forms.fields.title"
               {...register(`${name}.${index}.title` as Path<Partial<T>>, {
                 required: true,
               })}
@@ -44,7 +44,7 @@ function LinksRepeater<T extends FieldValues = FieldValues>({
           </Fieldset.Field>
           <Fieldset.Field>
             <Forms.Input
-              label="forms.inputs.linkRepeater.fields.url"
+              label="forms.fields.url"
               type="url"
               {...register(`${name}.${index}.url` as Path<Partial<T>>, {
                 required: true,

--- a/fixtures/app.data.ts
+++ b/fixtures/app.data.ts
@@ -1,31 +1,31 @@
 const COMMUNITIES_LINK = {
-  label: "glossary.community.label_plural",
+  label: "glossary.community_plural",
   route: "communities",
   actions: "communities.read",
   model: "communities",
 };
 
 const COLLECTIONS_LINK = {
-  label: "glossary.collection.label_plural",
+  label: "glossary.collection_plural",
   route: "collections",
   model: "collections",
 };
 
 const ITEMS_LINK = {
-  label: "glossary.item.label_plural",
+  label: "glossary.item_plural",
   route: "items",
   model: "items",
 };
 
 const USERS_LINK = {
-  label: "glossary.user.label_plural",
+  label: "glossary.user_plural",
   route: "users",
   actions: "users.read",
   model: "users",
 };
 
 const CONTRIBUTORS_LINK = {
-  label: "glossary.contributor.label_plural",
+  label: "glossary.contributor_plural",
   route: "contributors",
   actions: "contributors.read",
   model: "contributors",

--- a/locales/en.json
+++ b/locales/en.json
@@ -29,25 +29,24 @@
     "drawers": {
       "createPerson.title": "Create New Person",
       "createOrganization.title": "Create New Organization",
-      "editItemContribution.title": "Edit Item Contribution",
-      "editCollectionContribution.title": "Edit Collection Contribution",
       "createCommunity.title": "Create New Community",
       "createContribution.title": "Create New Contribution",
       "createFile.title": "Create New File",
+      "editItemContribution.title": "Edit Item Contribution",
+      "editCollectionContribution.title": "Edit Collection Contribution",
       "editCommunity.title": "Edit Community",
       "editCollection.title": "Edit Collection",
       "editContributor.title": "Edit Contributor",
       "editItem.title": "Edit Item",
-      "editCollectionContribution.title": "Collection Contribution",
-      "editItemContribution.title": "Item Contribution"
     },
     "actions": {
-      "add": "Add $t({{ name }})",
+      "create": "Create $t({{ name }})",
       "create.contributor.person": "Create Person",
       "create.contributor.organization": "Create Organization",
       "create.contribution": "Create Contribution",
       "create.community": "Create Community",
       "create.file": "Create File",
+      "edit": "Edit $t({{ name }})",
       "edit.itemContribution": "Edit Item Contribution",
       "edit.collectionContribution": "Edit Collection Contribution",
       "edit.community": "Edit Community",
@@ -197,50 +196,28 @@
       }
     },
     "glossary": {
-      "community": {
-        "label": "community",
-        "label_plural": "communities"
-      },
-      "collection": {
-        "label": "collection",
-        "label_plural": "collections"
-      },
-      "collection_contribution": {
-        "label": "collection $t(glossary.contribution.label_plural)"
-      },
-      "contribution": {
-        "label": "contribution",
-        "label_plural": "contributions"
-      },
-      "item": {
-        "label": "item",
-        "label_plural": "items"
-      },
-      "item_contribution": {
-        "label": "item $t(glossary.contribution.label_plural)"
-      },
-      "user": {
-        "label": "user",
-        "label_plural": "users"
-      },
-      "contributor": {
-        "label": "contributor",
-        "label_plural": "contributors",
-        "person": "Person",
-        "org": "Organization"
-      },
-      "link": {
-        "label": "link",
-        "label_plural": "links"
-      },
-      "ordering": {
-        "label": "ordering",
-        "label_plural": "orderings"
-      },
-      "file": {
-        "label": "file",
-        "label_plural": "files"
-      }
+      "community": "community",
+      "community_plural": "communities",
+      "collection": "collection",
+      "collection_plural": "collections",
+      "collection_contribution": "collection $t(glossary.contribution_plural)",
+      "contribution": "contribution",
+      "contribution_plural": "contributions",
+      "item": "item",
+      "item_plural": "items",
+      "item_contribution": "item $t(glossary.contribution_plural)",
+      "user": "user",
+      "user_plural": "users",
+      "contributor": "contributor",
+      "contributor_plural": "contributors",
+      "contributor_person": "Person",
+      "contributor_org": "Organization",
+      "link": "link",
+      "link_plural": "links",
+      "ordering": "ordering",
+      "ordering_plural": "orderings",
+      "file": "file",
+      "file_plural": "files"
     },
     "name": "name",
     "name_plural": "names",

--- a/locales/en.json
+++ b/locales/en.json
@@ -74,6 +74,30 @@
         "cancel": "Cancel",
         "save_and_close": "Save & Close"
       },
+      "fields": {
+        "title": "Title",
+        "thumbnail": "Thumbnail",
+        "visibility": "Visibility",
+        "summary": "Summary",
+        "visibleAfterAt": "Visible After",
+        "visibleUntilAt": "Visible Until",
+        "role": "Role",
+        "contributor": "Contributor",
+        "item": "Item",
+        "collection": "Collection",
+        "object": "Contribution on",
+        "legalName": "Name",
+        "givenName": "First Name",
+        "familyName": "Last Name",
+        "image": "Image",
+        "email": "Email",
+        "affiliation": "Affiliation",
+        "bio": "Bio",
+        "links": "Links",
+        "link": "Link",
+        "location": "Location",
+        "url": "URL"
+      },
       "tags": {
         "add": "Add tag",
         "enter": "Enter a new tag",
@@ -107,10 +131,6 @@
       },
       "inputs": {
         "linkRepeater": {
-          "fields": {
-            "url": "URL",
-            "title": "title"
-          },
           "add": "Add $t({{ itemLabel }})",
           "remove": "Remove $t({{ itemLabel }})"
         }
@@ -121,20 +141,9 @@
         },
         "update": {
           "success": "Community updated."
-        },
-        "fields": {
-          "title": "title"
         }
       },
       "collection": {
-        "fields": {
-          "title": "Title",
-          "thumbnail": "Thumbnail",
-          "visibility": "Visibility",
-          "summary": "Summary",
-          "visibleAfterAt": "Visible After",
-          "visibleUntilAt": "Visible Until"
-        },
         "update": {
           "success": "Collection updated.",
           "schemaSuccess": "Collection schema updated.",
@@ -143,13 +152,6 @@
         }
       },
       "contribution": {
-        "fields": {
-          "role": "Role",
-          "contributor": "Contributor",
-          "item": "Item",
-          "collection": "Collection",
-          "object": "Contribution on"
-        },
         "create": {
           "success": "Contribution created."
         },
@@ -158,14 +160,6 @@
         }
       },
       "item": {
-        "fields": {
-          "title": "Title",
-          "thumbnail": "Thumbnail",
-          "visibility": "Visibility",
-          "summary": "Summary",
-          "visibleAfterAt": "Visible After",
-          "visibleUntilAt": "Visible Until"
-        },
         "update": {
           "success": "Item updated.",
           "schemaSuccess": "Item schema updated.",
@@ -177,20 +171,6 @@
         "update": {
           "success": "Contributor updated.",
           "failure": "Contributor failed to update."
-        },
-        "fields": {
-          "legalName": "Name",
-          "givenName": "First Name",
-          "familyName": "Last Name",
-          "image": "Image",
-          "title": "Title",
-          "email": "Email",
-          "affiliation": "Affiliation",
-          "bio": "Bio",
-          "links": "Links",
-          "link": "Link",
-          "location": "Location",
-          "url": "URL"
         }
       }
     },

--- a/routes/baseRoutes.ts
+++ b/routes/baseRoutes.ts
@@ -8,23 +8,23 @@ export const baseRoutes: BaseRoute[] = [
   {
     name: "collections",
     path: "/collections",
-    label: "glossary.collection.label_plural",
+    label: "glossary.collection_plural",
     routes: [
       {
         name: "collection",
         path: "/collections/[slug]",
         redirect: "/collections/[slug]/collections",
-        label: "glossary.collection.label",
+        label: "glossary.collection",
         routes: [
           {
             name: "collection.child.collections",
             path: "/collections/[slug]/collections",
-            label: "glossary.collection.label_plural",
+            label: "glossary.collection_plural",
           },
           {
             name: "collection.child.items",
             path: "/collections/[slug]/items",
-            label: "glossary.item.label_plural",
+            label: "glossary.item_plural",
           },
           {
             name: "collection.manage",
@@ -71,18 +71,18 @@ export const baseRoutes: BaseRoute[] = [
   {
     name: "items",
     path: "/items",
-    label: "glossary.item.label_plural",
+    label: "glossary.item_plural",
     routes: [
       {
         name: "item",
         path: "/items/[slug]",
         redirect: "/items/[slug]/items",
-        label: "glossary.item.label_plural",
+        label: "glossary.item_plural",
         routes: [
           {
             name: "item.child.items",
             path: "/items/[slug]/items",
-            label: "glossary.item.label_plural",
+            label: "glossary.item_plural",
           },
           {
             name: "item.manage",
@@ -135,18 +135,18 @@ export const baseRoutes: BaseRoute[] = [
   {
     name: "communities",
     path: "/communities",
-    label: "glossary.community.label_plural",
+    label: "glossary.community_plural",
     routes: [
       {
         name: "community",
         path: "/communities/[slug]",
         redirect: "/communities/[slug]/collections",
-        label: "glossary.community.label_plural",
+        label: "glossary.community_plural",
         routes: [
           {
             name: "community.child.collections",
             path: "/communities/[slug]/collections",
-            label: "glossary.collection.label_plural",
+            label: "glossary.collection_plural",
           },
           {
             name: "community.manage",
@@ -174,13 +174,13 @@ export const baseRoutes: BaseRoute[] = [
   {
     name: "users",
     path: "/users",
-    label: "glossary.user.label_plural",
+    label: "glossary.user_plural",
     routes: [
       {
         name: "user",
         path: "/users/[slug]",
         redirect: "/users/[slug]/details",
-        label: "glossary.user.label_plural",
+        label: "glossary.user_plural",
         routes: [
           {
             name: "user.details",
@@ -209,13 +209,13 @@ export const baseRoutes: BaseRoute[] = [
   {
     name: "contributors",
     path: "/contributors",
-    label: "glossary.contributor.label_plural",
+    label: "glossary.contributor_plural",
     routes: [
       {
         name: "contributor",
         path: "/contributors/[slug]",
         redirect: "/contributors/[slug]/details",
-        label: "glossary.contributor.label_plural",
+        label: "glossary.contributor_plural",
         routes: [
           {
             name: "contributor.details",


### PR DESCRIPTION
The problem:
We're repeating ourselves a lot in our translation files, specifically with glossary terms (Contributor, Collection, etc) and field values. This POC cleans up the field values, and shows how we can clean up translations by passing in the glossary term we need, rather than repeating ourselves in the translation document. This could mean easier translations (less words to translate), but a slightly more complex translation lookup for developers. 

For example:
Instead of repeating ourselves in the translation file, we use one "action.edit" string, and pass in the name:
https://github.com/NGLPteam/wdp-admin-ui/pull/170/files#diff-c9218bed23f0aeb93d7e1a7d5f6e1345fae20f4b8692b27fb97fd0f37b3d26d7L43-R44
```
"actions": {
    "edit": "Edit $t({{ name }})"
}
```
Then, where we need to use the string, we pass in the name:
```
<Drawer label={t("actions.edit", { name: "glossary.collection" })} ... />
```
If we use this pattern throughout the translation file, then we only need to translate "Collection" once. 