### PR TITLE
[B] Remove name label from grids

### DIFF
--- a/components/composed/model/ModelColumns/NameColumn.tsx
+++ b/components/composed/model/ModelColumns/NameColumn.tsx
@@ -14,7 +14,7 @@ const NameColumn = <NodeType extends Node>({
 
   return {
     Header: <>{t("columns.name")}</>,
-    id: "Name",
+    id: "name",
     disableSortBy: true,
     Cell: ({ row, value }: CellProps<NodeType>) => {
       if (!row?.original?.slug) return value;

--- a/components/composed/model/ModelGrid/ModelGridItem.tsx
+++ b/components/composed/model/ModelGrid/ModelGridItem.tsx
@@ -30,7 +30,7 @@ function ModelGridItem<T extends Record<string, unknown>>({ row }: Props<T>) {
 
           return (
             <div key={i}>
-              {cell.column.id !== "title" && cell.column.id !== "name" && (
+              {cell.column.id !== "title" && cell.column.id !== "Name" && (
                 <span>
                   {cell.render("Header")}
                   {`: `}

--- a/components/composed/model/ModelGrid/ModelGridItem.tsx
+++ b/components/composed/model/ModelGrid/ModelGridItem.tsx
@@ -25,17 +25,21 @@ function ModelGridItem<T extends Record<string, unknown>>({ row }: Props<T>) {
     >
       <>
         {row.cells.map((cell, i) => {
-          if (cell.column.id === "actions" || cell.column.id === "thumbnail")
+          if (
+            cell.column.id.toLowerCase() === "actions" ||
+            cell.column.id.toLowerCase() === "thumbnail"
+          )
             return;
 
           return (
             <div key={i}>
-              {cell.column.id !== "title" && cell.column.id !== "Name" && (
-                <span>
-                  {cell.render("Header")}
-                  {`: `}
-                </span>
-              )}
+              {cell.column.id.toLowerCase() !== "title" &&
+                cell.column.id.toLowerCase() !== "name" && (
+                  <span>
+                    {cell.render("Header")}
+                    {`: `}
+                  </span>
+                )}
               {cell.render("Cell")}
             </div>
           );


### PR DESCRIPTION
@jen-castiron This was literally a one-letter fix, but I wanted to flag that problem was matching a case sensitive string in case we want to do more to make these consistent. "Name" seems to be the only `id` value that's capitalized.