### PR TITLE
[C] Refactor ButtonControlGroup to reduce complexity

### DIFF
--- a/components/atomic/buttons/ButtonControlGroup/ButtonControlGroup.stories.tsx
+++ b/components/atomic/buttons/ButtonControlGroup/ButtonControlGroup.stories.tsx
@@ -1,6 +1,12 @@
 import ButtonControlGroup from "./ButtonControlGroup";
+import ButtonControl, {
+  ButtonControlDrawer,
+  ButtonControlConfirm,
+} from "components/atomic/buttons/ButtonControl";
 import { Story } from "@storybook/react";
 import { breakpoints } from "theme/base/variables";
+import i18next from "i18next";
+
 type Props = React.ComponentProps<typeof ButtonControlGroup>;
 
 export default {
@@ -26,7 +32,21 @@ const Template: Story<Props> = (args) => (
       width.
     </p>
     <br />
-    <ButtonControlGroup {...args} />
+    <ButtonControlGroup {...args}>
+      <ButtonControlDrawer drawer="addPerson" icon="plus">
+        {"Add"}
+      </ButtonControlDrawer>
+      <ButtonControl icon="edit">{"Edit"}</ButtonControl>
+      <ButtonControlConfirm
+        icon="delete"
+        modalLabel={i18next.t("modals.delete.label")}
+        modalBody={
+          <p className="t-copy-sm">{i18next.t("modals.delete.body")}</p>
+        }
+      >
+        {"Delete"}
+      </ButtonControlConfirm>
+    </ButtonControlGroup>
   </>
 );
 
@@ -34,46 +54,46 @@ export const Default: Story<Props> = Template.bind({});
 
 Default.args = {
   toggleLabel: "Options",
-  buttons: [
-    {
-      children: "Add",
-      drawer: "addPerson",
-      icon: "plus",
-    },
-    {
-      children: "Edit",
-      icon: "edit",
-    },
-    {
-      children: "Delete",
-      icon: "delete",
-    },
-  ],
 };
 
-export const WithAuthActions: Story<Props> = Template.bind({});
+export const WithAuthActions: Story<Props> = (args) => (
+  <>
+    <p>
+      Actions collapse into a dropdown when browser width is &lt; breakpoint
+      width.
+    </p>
+    <br />
+    <ButtonControlGroup {...args}>
+      <ButtonControlDrawer
+        drawer="addPerson"
+        icon="plus"
+        actions="self.add"
+        allowedActions={["self.edit", "self.add"]}
+      >
+        {"Add"}
+      </ButtonControlDrawer>
+      <ButtonControl
+        icon="edit"
+        actions="self.edit"
+        allowedActions={["self.edit", "self.add"]}
+      >
+        {"Edit"}
+      </ButtonControl>
+      <ButtonControlConfirm
+        icon="delete"
+        modalLabel={i18next.t("modals.delete.label")}
+        modalBody={
+          <p className="t-copy-sm">{i18next.t("modals.delete.body")}</p>
+        }
+        actions="self.delete"
+        allowedActions={["self.edit", "self.add"]}
+      >
+        {"Delete"}
+      </ButtonControlConfirm>
+    </ButtonControlGroup>
+  </>
+);
 
 WithAuthActions.args = {
   toggleLabel: "Options",
-  buttons: [
-    {
-      children: "Add",
-      drawer: "addPerson",
-      icon: "plus",
-      actions: "self.add",
-      allowedActions: ["self.edit", "self.add"],
-    },
-    {
-      children: "Edit",
-      icon: "edit",
-      actions: "self.edit",
-      allowedActions: ["self.edit", "self.add"],
-    },
-    {
-      children: "Delete",
-      icon: "delete",
-      actions: "self.delete",
-      allowedActions: ["self.edit", "self.add"],
-    },
-  ],
 };

--- a/components/atomic/buttons/ButtonControlGroup/ButtonControlGroup.tsx
+++ b/components/atomic/buttons/ButtonControlGroup/ButtonControlGroup.tsx
@@ -13,73 +13,40 @@ type ButtonProps =
   | React.ComponentProps<typeof ButtonControlConfirm>;
 
 function ButtonControlGroup({
-  buttons,
   breakpoint = 40,
+  children,
   menuLabel,
-  toggleLabel,
   toggleText,
+  toggleLabel,
 }: Props) {
-  function renderButton(props: ButtonProps, i: number) {
-    const { children, ...buttonProps } = props;
-
-    return "drawer" in props ? (
-      <ButtonControlDrawer
-        key={i}
-        drawer={props.drawer}
-        drawerQuery={props.drawerQuery}
-        {...buttonProps}
-      >
-        {children}
-      </ButtonControlDrawer>
-    ) : "modalBody" in props ? (
-      <ButtonControlConfirm
-        key={i}
-        modalBody={props.modalBody}
-        modalLabel={props.modalLabel}
-        {...buttonProps}
-      >
-        {children}
-      </ButtonControlConfirm>
-    ) : (
-      <ButtonControl key={i} {...buttonProps}>
-        {children}
-      </ButtonControl>
-    );
-  }
-
-  function renderDropdown(buttons: ButtonProps[]) {
-    return (
-      <Dropdown
-        label={menuLabel}
-        disclosure={
-          <ButtonControl icon="ellipses" aria-label={toggleLabel}>
-            {toggleText}
-          </ButtonControl>
-        }
-        menuItems={buttons.map(renderButton)}
-      />
-    );
-  }
-
   return (
     <>
       <Styled.ButtonWrapper breakpoint={breakpoint}>
-        {buttons.map(renderButton)}
+        {children}
       </Styled.ButtonWrapper>
       <Styled.DropdownWrapper breakpoint={breakpoint}>
-        {renderDropdown(buttons)}
+        <Dropdown
+          label={menuLabel}
+          disclosure={
+            <ButtonControl icon="ellipses" aria-label={toggleLabel}>
+              {toggleText}
+            </ButtonControl>
+          }
+          menuItems={Array.isArray(children) ? children : [children]}
+        />
       </Styled.DropdownWrapper>
     </>
   );
 }
 
 interface BaseProps {
-  buttons: ButtonProps[];
+  buttons?: ButtonProps[];
   breakpoint?: string | number;
   menuLabel: string;
   toggleLabel?: string;
   toggleText?: string;
   closeDropdown?: () => void;
+  children: React.ReactElement<ButtonProps> | React.ReactElement<ButtonProps>[];
 }
 
 interface PropsWithLabel extends BaseProps {

--- a/components/atomic/dropdown/Dropdown/Dropdown.tsx
+++ b/components/atomic/dropdown/Dropdown/Dropdown.tsx
@@ -32,7 +32,7 @@ const Dropdown = ({ className, disclosure, menuItems, label }: Props) => {
         if (item === null) return null;
         return (
           <Styled.Item key={i}>
-            {React.cloneElement(item, { closeDropdown: closeDropdown })}
+            {item && React.cloneElement(item, { closeDropdown: closeDropdown })}
           </Styled.Item>
         );
       })}

--- a/components/composed/community/CommunityList/CommunityList.tsx
+++ b/components/composed/community/CommunityList/CommunityList.tsx
@@ -12,7 +12,7 @@ import { useMaybeFragment, useDrawerHelper, useDestroyer } from "hooks";
 import ModelListPage from "components/composed/model/ModelListPage";
 import ModelColumns from "components/composed/model/ModelColumns";
 import PageHeader from "components/layout/PageHeader";
-import { ButtonControlGroup } from "components/atomic";
+import { ButtonControlDrawer, ButtonControlGroup } from "components/atomic";
 
 type HeaderProps = React.ComponentProps<typeof PageHeader>;
 
@@ -47,17 +47,11 @@ function CommunityList<T extends OperationType>({
   };
 
   const buttons = (
-    <ButtonControlGroup
-      buttons={[
-        {
-          drawer: "addCommunity",
-          icon: "plus",
-          children: t("actions.create.community"),
-        },
-      ]}
-      toggleLabel={t("options")}
-      menuLabel={t("options")}
-    />
+    <ButtonControlGroup toggleLabel={t("options")} menuLabel={t("options")}>
+      <ButtonControlDrawer drawer="addCommunity" icon="plus">
+        {t("actions.create.community")}
+      </ButtonControlDrawer>
+    </ButtonControlGroup>
   );
 
   return (

--- a/components/composed/contribution/CollectionContributionList/CollectionContributionList.tsx
+++ b/components/composed/contribution/CollectionContributionList/CollectionContributionList.tsx
@@ -14,7 +14,11 @@ import {
   useRouteSlug,
 } from "hooks";
 
-import { ButtonControlGroup, NamedLink } from "components/atomic";
+import {
+  ButtonControlGroup,
+  NamedLink,
+  ButtonControlDrawer,
+} from "components/atomic";
 import ModelListPage from "components/composed/model/ModelListPage";
 import ModelColumns from "components/composed/model/ModelColumns";
 import GetContributorDisplayName from "components/composed/contributor/ContributorDisplayName";
@@ -113,25 +117,23 @@ function CollectionContributionList<T extends OperationType>({
     drawerSlug: slug || "",
     drawerContributionType: "collection",
   };
+  const drawer =
+    nameColumn === "contributor"
+      ? "addCollectionContribution"
+      : "addContributorContribution";
 
   // TODO: We need an authorization check here. The contributors.create check doesn't
   //  exist yet in the API.
   const buttons = (
-    <ButtonControlGroup
-      buttons={[
-        {
-          drawer:
-            nameColumn === "contributor"
-              ? "addCollectionContribution"
-              : "addContributorContribution",
-          drawerQuery,
-          icon: "plus",
-          children: t("actions.create.contribution"),
-        },
-      ]}
-      toggleLabel={t("options")}
-      menuLabel={t("options")}
-    />
+    <ButtonControlGroup toggleLabel={t("options")} menuLabel={t("options")}>
+      <ButtonControlDrawer
+        icon="plus"
+        drawer={drawer}
+        drawerQuery={drawerQuery}
+      >
+        {t("actions.create.contribution")}
+      </ButtonControlDrawer>
+    </ButtonControlGroup>
   );
 
   return (

--- a/components/composed/contribution/ItemContributionList/ItemContributionList.tsx
+++ b/components/composed/contribution/ItemContributionList/ItemContributionList.tsx
@@ -16,7 +16,11 @@ import {
 
 import ModelListPage from "components/composed/model/ModelListPage";
 import ModelColumns from "components/composed/model/ModelColumns";
-import { ButtonControlGroup, NamedLink } from "components/atomic";
+import {
+  ButtonControlGroup,
+  NamedLink,
+  ButtonControlDrawer,
+} from "components/atomic";
 import GetContributorDisplayName from "components/composed/contributor/ContributorDisplayName/ContributorDisplayName";
 import PageHeader from "components/layout/PageHeader";
 import { useTranslation } from "react-i18next";
@@ -109,24 +113,23 @@ function ItemContributionList<T extends OperationType>({
     drawerContributionType: "item",
   };
 
+  const drawer =
+    nameColumn === "contributor"
+      ? "addItemContribution"
+      : "addContributorContribution";
+
   // TODO: We need an authorization check here. The contributors.create check doesn't
   //  exist yet in the API.
   const buttons = (
-    <ButtonControlGroup
-      buttons={[
-        {
-          drawer:
-            nameColumn === "contributor"
-              ? "addItemContribution"
-              : "addContributorContribution",
-          drawerQuery,
-          icon: "plus",
-          children: t("actions.create.contribution"),
-        },
-      ]}
-      toggleLabel={t("options")}
-      menuLabel={t("options")}
-    />
+    <ButtonControlGroup toggleLabel={t("options")} menuLabel={t("options")}>
+      <ButtonControlDrawer
+        icon="plus"
+        drawer={drawer}
+        drawerQuery={drawerQuery}
+      >
+        {t("actions.create.contribution")}
+      </ButtonControlDrawer>
+    </ButtonControlGroup>
   );
 
   return (

--- a/components/composed/contributor/ContributorList/ContributorList.tsx
+++ b/components/composed/contributor/ContributorList/ContributorList.tsx
@@ -11,7 +11,7 @@ import { useTranslation } from "react-i18next";
 import { useMaybeFragment, useDestroyer, useDrawerHelper } from "hooks";
 
 import ModelColumns from "components/composed/model/ModelColumns";
-import { ButtonControlGroup } from "components/atomic";
+import { ButtonControlGroup, ButtonControlDrawer } from "components/atomic";
 import { getContributorDisplayName } from "../ContributorDisplayName";
 import PageHeader from "components/layout/PageHeader";
 
@@ -61,22 +61,14 @@ function ContributorList<T extends OperationType>({
   // TODO: We need an authorization check here. The contributors.create check doesn't
   //  exist yet in the API.
   const buttons = (
-    <ButtonControlGroup
-      buttons={[
-        {
-          drawer: "addPerson",
-          icon: "plus",
-          children: t("actions.create.contributor.person"),
-        },
-        {
-          drawer: "addOrganization",
-          icon: "plus",
-          children: t("actions.create.contributor.organization"),
-        },
-      ]}
-      toggleLabel={t("options")}
-      menuLabel={t("options")}
-    />
+    <ButtonControlGroup toggleLabel={t("options")} menuLabel={t("options")}>
+      <ButtonControlDrawer drawer="addPerson" icon="plus">
+        {t("actions.create.contributor.person")}
+      </ButtonControlDrawer>
+      <ButtonControlDrawer drawer="addOrganization" icon="plus">
+        {t("actions.create.contributor.organization")}
+      </ButtonControlDrawer>
+    </ButtonControlGroup>
   );
 
   return (

--- a/components/composed/file/FileList/FileList.tsx
+++ b/components/composed/file/FileList/FileList.tsx
@@ -12,7 +12,7 @@ import ModelListPage from "components/composed/model/ModelListPage";
 import ModelColumns from "components/composed/model/ModelColumns";
 import PageHeader from "components/layout/PageHeader";
 import { useTranslation } from "react-i18next";
-import { ButtonControlGroup } from "components/atomic";
+import { ButtonControlGroup, ButtonControlDrawer } from "components/atomic";
 
 type HeaderProps = React.ComponentProps<typeof PageHeader>;
 
@@ -61,18 +61,15 @@ function FileList<T extends OperationType>({
   // TODO: We need an authorization check here.
   // There are currently no allowedActions around assets.
   const buttons = (
-    <ButtonControlGroup
-      buttons={[
-        {
-          drawer: "addFile",
-          drawerQuery: { drawerSlug: slug || "" },
-          icon: "plus",
-          children: t("actions.create.file"),
-        },
-      ]}
-      toggleLabel={t("options")}
-      menuLabel={t("options")}
-    />
+    <ButtonControlGroup toggleLabel={t("options")} menuLabel={t("options")}>
+      <ButtonControlDrawer
+        icon="plus"
+        drawer="addFile"
+        drawerQuery={{ drawerSlug: slug || "" }}
+      >
+        {t("actions.create.file")}
+      </ButtonControlDrawer>
+    </ButtonControlGroup>
   );
 
   return (

--- a/components/composed/model/ModelList/hooks/useRowActions.tsx
+++ b/components/composed/model/ModelList/hooks/useRowActions.tsx
@@ -1,6 +1,10 @@
 import React from "react";
 import i18next from "i18next";
-import { ButtonControlGroup } from "components/atomic/buttons";
+import {
+  ButtonControlGroup,
+  ButtonControl,
+  ButtonControlConfirm,
+} from "components/atomic/buttons";
 import type { Hooks, Row } from "react-table";
 import IconFactory from "components/factories/IconFactory";
 type IconFactoryProps = React.ComponentProps<typeof IconFactory>;
@@ -46,38 +50,43 @@ const availableActions: ActionDefinitions = {
   },
 };
 
-function getButtonProps<D extends Record<string, unknown>>(
+function getButtonControlChildren<D extends Record<string, unknown>>(
   row: Row<D>,
   action: ActionKeys,
   actionConfig?: ActionConfig<D>
 ) {
   const actionDefinition = availableActions[action];
 
-  const buttonProps = actionConfig?.modalConfirm
-    ? {
-        "aria-label": actionDefinition.label,
-        icon: actionDefinition.icon,
-        iconRotate: actionDefinition.iconRotate || 0,
-        ...(actionConfig?.handleClick && {
-          onClick: () => actionConfig.handleClick({ row }),
-        }),
-        modalLabel: actionDefinition.modalLabel ?? null,
-        modalBody: actionDefinition.modalBody ?? null,
-      }
-    : {
-        "aria-label": actionDefinition.label,
-        icon: actionDefinition.icon,
-        iconRotate: actionDefinition.iconRotate || 0,
-        ...(actionConfig?.handleClick && {
-          onClick: () => actionConfig.handleClick({ row }),
-        }),
-      };
+  const buttonControl = actionConfig?.modalConfirm ? (
+    <ButtonControlConfirm
+      aria-label={actionDefinition.label}
+      icon={actionDefinition.icon}
+      iconRotate={actionDefinition.iconRotate || 0}
+      {...(actionConfig?.handleClick && {
+        onClick: () => actionConfig.handleClick({ row }),
+      })}
+      modalLabel={actionDefinition.modalLabel}
+      modalBody={actionDefinition.modalBody ?? null}
+    ></ButtonControlConfirm>
+  ) : (
+    <ButtonControl
+      aria-label={actionDefinition.label}
+      icon={actionDefinition.icon}
+      iconRotate={actionDefinition.iconRotate || 0}
+      {...(actionConfig?.handleClick && {
+        onClick: () => actionConfig.handleClick({ row }),
+      })}
+    ></ButtonControl>
+  );
 
   const allowedActions = row?.original?.allowedActions as string[] | undefined;
 
-  if (!allowedActions) return buttonProps;
+  if (!allowedActions) return buttonControl;
 
-  return { ...buttonProps, actions: actionDefinition.action, allowedActions };
+  return React.cloneElement(buttonControl, {
+    actions: actionDefinition.action,
+    allowedActions,
+  });
 }
 
 function renderActions<D extends Record<string, unknown>>(
@@ -94,7 +103,7 @@ function renderActions<D extends Record<string, unknown>>(
     .map((action) => {
       // Map actions to button props
       const actionConfig = configuration[action];
-      return getButtonProps<D>(row, action, actionConfig);
+      return getButtonControlChildren<D>(row, action, actionConfig);
     });
 
   return buttons ? (
@@ -102,8 +111,9 @@ function renderActions<D extends Record<string, unknown>>(
       toggleLabel={i18next.t("options")}
       menuLabel={"Options list"}
       breakpoint={70}
-      buttons={buttons}
-    />
+    >
+      {buttons}
+    </ButtonControlGroup>
   ) : null;
 }
 

--- a/components/layout/Grid/Grid.stories.tsx
+++ b/components/layout/Grid/Grid.stories.tsx
@@ -1,5 +1,5 @@
 import { Story } from "@storybook/react";
-import { ButtonControlGroup, Image } from "components/atomic";
+import { ButtonControlGroup, Image, ButtonControl } from "components/atomic";
 import Grid from "./";
 
 type Props = React.ComponentProps<typeof Grid>;
@@ -103,11 +103,10 @@ export const WithActions: Story<Props> = ({ showCheckboxes }) => (
             <ButtonControlGroup
               toggleLabel="Options"
               menuLabel="Toggle options"
-              buttons={[
-                { icon: "edit", "aria-label": "Edit item" },
-                { icon: "delete", "aria-label": "Delete item" },
-              ]}
-            />
+            >
+              <ButtonControl icon="edit" aria-label="Edit item" />
+              <ButtonControl icon="delete" aria-label="Delete item" />
+            </ButtonControlGroup>
           }
           thumbnail={renderRandImage()}
         >


### PR DESCRIPTION
This PR simplifies `ButtonControlGroup` so that it no longer needs to know the possible types of its children. Rather than taking a prop object with options and creating `ButtonControl` children inside `ButtonControlGroup`, the group now accepts children of the various button control patterns and is only responsible for determining whether to render a row of buttons or a dropdown.

Usage:
```
<ButtonControlGroup>
  <ButtonControl>A plain button</ButtonControl>
  <ButtonControlDrawer icon="edit" drawer="...">A drawer button, like edit</ButtonControlDrawer>
  <ButtonControlConfirm icon="delete" modalBody="...">A confirmation button, like delete</ButtonControlConfirm>
</ButtonControlGroup>
```

Note: `useRowActions` was modified to create button children rather than the `buttonProps` object for this new pattern, but we are using `ButtonControl` rather than `ButtonControlDrawer` for buttons with a drawer link here so that no modifications to the `actions` objects are required.
